### PR TITLE
Remount /sysroot rw

### DIFF
--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -6,6 +6,10 @@ DefaultDependencies=false
 Requires=initrd-root-fs.target
 After=initrd-root-fs.target
 
+# Make sure root filesysem is mounted read-write
+Requires=ignition-remount-sysroot.service
+After=ignition-remount-sysroot.service
+
 # Run before initrd-parse-etc so that we can drop files it then picks up.
 Before=initrd-parse-etc.service
 

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -6,7 +6,7 @@ DefaultDependencies=false
 Requires=initrd-root-fs.target
 After=initrd-root-fs.target
 
-# Make sure root filesysem is mounted read-write
+# Make sure root filesystem is mounted read-write
 Requires=ignition-remount-sysroot.service
 After=ignition-remount-sysroot.service
 

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=Remount /sysroot read-write for Ignition
+# Some Linux Distributions don't pass a rw option on the kernel
+# commandline and thus mount the root filesystem ro by default. In
+# this case, remount /sysroot to rw (issue #37)
 DefaultDependencies=no
 After=sysroot.mount
 ConditionPathIsReadWrite=!/sysroot

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Remount /sysroot read-write for Ignition
+DefaultDependencies=no
+After=sysroot.mount
+ConditionPathIsReadWrite=!/sysroot
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/mount -o remount,rw /sysroot

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -44,6 +44,9 @@ install() {
     inst_simple "$moddir/ignition-ask-var-mount.service" \
         "$systemdsystemunitdir/ignition-ask-var-mount.service"
 
+    inst_simple "$moddir/ignition-remount-sysroot.service" \
+        "$systemdutildir/system/ignition-remount-sysroot.service"
+
 #   inst_simple "$moddir/sysroot-boot.service" \
 #       "$systemdsystemunitdir/sysroot-boot.service"
 


### PR DESCRIPTION
Some Linux Distributions don't pass a rw option on the kernel commandline
and thus mount the root filesystem ro by default. In this case, remount
/sysroot to rw (issue #37)