### PR TITLE
journal: add clarifying comment for context

### DIFF
--- a/dracut/99journald-conf/00-journal-log-forwarding.conf
+++ b/dracut/99journald-conf/00-journal-log-forwarding.conf
@@ -1,3 +1,12 @@
 [Journal]
+# For now we are using kmsg for multiplexing output to
+# multiple console devices during early boot.
+# 
+# We do not want to use kmsg in the future as there may be sensitive
+# ignition data that leaks to non-root users (by reading the kernel
+# ring buffer using `dmesg`). In the future we will rely on kernel
+# console multiplexing (link below) for this and will not use kmsg.
+# 
+# https://github.com/coreos/fedora-coreos-tracker/issues/136
 ForwardToKMsg=yes
 MaxLevelKMsg=info


### PR DESCRIPTION
It's good to provide some history so that we can know
when we can drop these changes.