### PR TITLE
support platform configs and user configs in /boot

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -12,6 +12,11 @@ After=basic.target
 Before=initrd-root-fs.target
 Before=sysroot.mount
 
+# Require and run after ignition-setup has run because ignition-setup
+# may copy in new/different ignition configs for us to consume.
+Requires=ignition-setup.service
+After=ignition-setup.service
+
 # Network may be used to fetch userdata content.
 After=network.target
 

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -6,6 +6,11 @@ DefaultDependencies=false
 Requires=initrd-root-fs.target
 After=initrd-root-fs.target
 
+# Require and run after ignition-setup has run because ignition-setup
+# may copy in new/different ignition configs for us to consume.
+Requires=ignition-setup.service
+After=ignition-setup.service
+
 # Make sure root filesystem is mounted read-write
 Requires=ignition-remount-sysroot.service
 After=ignition-remount-sysroot.service
@@ -15,6 +20,10 @@ Before=initrd-parse-etc.service
 
 # Network may be required to fetch userdata content.
 After=network.target
+
+# This is guaranteed through After=initrd-root-fs.target but just to
+# be explicit we'll add an After=ignition-disks.service here.
+After=ignition-disks.service
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -39,6 +39,7 @@ if $(cmdline_bool 'ignition.firstboot' 0); then
     add_requires ignition-disks.service
     add_requires ignition-files.service
     add_requires ignition-ask-var-mount.service
+    add_requires ignition-setup.service
     #if [[ $(cmdline_arg coreos.oem.id) == "packet" ]]; then
     #    add_requires coreos-static-network.service
     #fi
@@ -64,6 +65,8 @@ DefaultDependencies=false
 
 Requires=local-fs-pre.target
 Before=local-fs-pre.target
+Before=ignition-disks.service
+Before=ignition-files.service
 
 Requires=dev-disk-by\x2dlabel-boot.device
 After=dev-disk-by\x2dlabel-boot.device

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -70,6 +70,7 @@ After=dev-disk-by\x2dlabel-boot.device
 
 [Service]
 Type=oneshot
+EnvironmentFile=/run/ignition.env
 ExecStart=/usr/sbin/ignition-setup
 EOF
 

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -75,6 +75,9 @@ After=dev-disk-by\x2dlabel-boot.device
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
+# The MountFlags=slave is so the umount of /boot is guaranteed to happen
+# /boot will only be mounted for the lifetime of the unit.
+MountFlags=slave
 ExecStart=/usr/sbin/ignition-setup
 EOF
 

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -39,7 +39,6 @@ if $(cmdline_bool 'ignition.firstboot' 0); then
     add_requires ignition-disks.service
     add_requires ignition-files.service
     add_requires ignition-ask-var-mount.service
-    add_requires ignition-setup.service
     #if [[ $(cmdline_arg coreos.oem.id) == "packet" ]]; then
     #    add_requires coreos-static-network.service
     #fi

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -70,6 +70,7 @@ After=dev-disk-by\x2dlabel-boot.device
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
 ExecStart=/usr/sbin/ignition-setup
 EOF

--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -7,7 +7,8 @@ src=/usr/share/oem
 
 dst=/usr/lib/ignition
 mkdir -p "${dst}"
-for name in base.ign default.ign; do
+
+for name in base.ign; do
     if [[ -e "${src}/base/${name}" ]]; then
         cp "${src}/base/${name}" "${dst}"
     fi

--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-copy_file() {
+copy_file_if_exists() {
     src="${1}"; dst="${2}"
     if [ -f "${src}" ]; then
         echo "Copying ${src} to ${dst}"
@@ -16,14 +16,14 @@ mkdir -p $destination
 
 # We will support grabbing a platform specific base.ign config
 # from the initrd at /usr/lib/ignition/platform/${OEM_ID}/base.ign
-copy_file "/usr/lib/ignition/platform/${OEM_ID}/base.ign" "${destination}/base.ign"
+copy_file_if_exists "/usr/lib/ignition/platform/${OEM_ID}/base.ign" "${destination}/base.ign"
 
 # We will support a user embedded config in the boot partition
 # under $bootmnt/ignition/config.ign
 bootmnt=/mnt/boot_partition
 mkdir -p $bootmnt
 mount /dev/disk/by-label/boot $bootmnt
-copy_file "${bootmnt}/ignition/config.ign" "${destination}/user.ign"
+copy_file_if_exists "${bootmnt}/ignition/config.ign" "${destination}/user.ign"
 # This script is run from a systemd unit with MountFlags=slave. This
 # unmount isn't strictly necessary, but we still exercise it here.
 umount $bootmnt

--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 set -eux
 
+bootmnt=/mnt/boot_partition
+
 # Grab our ignition configs from:
 #  - A platform specific directory for this platform
 #  - The boot partition (user/installer overrides)
 sources=("/usr/share/platforms/${OEM_ID}/"
-         "/boot/ignition/")
+         "${bootmnt}/ignition/")
+
+# mount the boot partition
+mkdir -p $bootmnt
+mount /dev/disk/by-label/boot $bootmnt
 
 # files go into the /usr/lib/ignition directory
 dst=/usr/lib/ignition
@@ -20,3 +26,5 @@ for src in ${sources[*]}; do
         done
     fi
 done
+
+umount $bootmnt

--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -24,4 +24,6 @@ bootmnt=/mnt/boot_partition
 mkdir -p $bootmnt
 mount /dev/disk/by-label/boot $bootmnt
 copy_file "${bootmnt}/ignition/config.ign" "${destination}/user.ign"
+# This script is run from a systemd unit with MountFlags=slave. This
+# unmount isn't strictly necessary, but we still exercise it here.
 umount $bootmnt

--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -19,11 +19,10 @@ mkdir -p $destination
 copy_file_if_exists "/usr/lib/ignition/platform/${OEM_ID}/base.ign" "${destination}/base.ign"
 
 # We will support a user embedded config in the boot partition
-# under $bootmnt/ignition/config.ign
+# under $bootmnt/ignition/config.ign. Note that we mount /boot
+# but we don't unmount boot because we are run in a systemd unit
+# with MountFlags=slave so it is unmounted for us.
 bootmnt=/mnt/boot_partition
 mkdir -p $bootmnt
 mount /dev/disk/by-label/boot $bootmnt
 copy_file_if_exists "${bootmnt}/ignition/config.ign" "${destination}/user.ign"
-# This script is run from a systemd unit with MountFlags=slave. This
-# unmount isn't strictly necessary, but we still exercise it here.
-umount $bootmnt

--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -1,23 +1,22 @@
 #!/bin/bash
+set -eux
 
-set -e
+# Grab our ignition configs from:
+#  - A platform specific directory for this platform
+#  - The boot partition (user/installer overrides)
+sources=("/usr/share/platforms/${OEM_ID}/"
+         "/boot/ignition/")
 
-# OEM directory in the initramfs itself
-src=/usr/share/oem
-
+# files go into the /usr/lib/ignition directory
 dst=/usr/lib/ignition
 mkdir -p "${dst}"
 
-for name in base.ign; do
-    if [[ -e "${src}/base/${name}" ]]; then
-        cp "${src}/base/${name}" "${dst}"
+for src in ${sources[*]}; do
+    if [ -d "$src" ]; then
+        for name in 'base.ign' 'user.ign'; do
+            if [ -f "${src}/${name}" ]; then
+                cp "${src}/${name}" "${dst}"
+            fi
+        done
     fi
 done
-if [[ -e "${src}/config.ign" ]]; then
-    cp "${src}/config.ign" "${dst}/user.ign"
-fi
-
-# if we have config.ign on boot, overwrite it
-if [[ -e "/boot/config.ign" ]]; then
-    cp "/boot/config.ign" "${dst}/user.ign"
-fi

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -26,8 +26,8 @@ install() {
     # This one is optional; https://src.fedoraproject.org/rpms/ignition/pull-request/9
     inst_multiple -o mkfs.btrfs
 
-#   inst_script "$moddir/ignition-setup.sh" \
-#       "/usr/sbin/ignition-setup"
+    inst_script "$moddir/ignition-setup.sh" \
+        "/usr/sbin/ignition-setup"
 
 #   inst_script "$moddir/retry-umount.sh" \
 #       "/usr/sbin/retry-umount"


### PR DESCRIPTION
This PR lays some ground work for supporting platform configs based on OEM
id and also support for embedded user configs in /boot/ (bare metal install use case). 