### PR TITLE
dracut: adapt for s/oem/platform in Ignition

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -27,4 +27,4 @@ After=systemd-udevd.service
 [Service]
 Type=oneshot
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=disks
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=disks

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -28,4 +28,4 @@ After=ignition-disks.service
 [Service]
 Type=oneshot
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=files --log-to-stdout
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=files --log-to-stdout

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -17,6 +17,9 @@ cmdline_arg() {
     echo "${value}"
 }
 
+# check *both* old and new keys for now
+platform_id=$(cmdline_arg ignition.platform.id "$(cmdline_arg coreos.oem.id)")
+
 cmdline_bool() {
     local value=$(cmdline_arg "$@")
     case "$value" in
@@ -39,13 +42,13 @@ if $(cmdline_bool 'ignition.firstboot' 0); then
     add_requires ignition-disks.service
     add_requires ignition-files.service
     add_requires ignition-ask-var-mount.service
-    #if [[ $(cmdline_arg coreos.oem.id) == "packet" ]]; then
+    #if [[ $platform_id == "packet" ]]; then
     #    add_requires coreos-static-network.service
     #fi
 
     # On EC2, shut down systemd-networkd if ignition fails so that the instance
     # fails EC2 instance checks.
-    #if [[ $(cmdline_arg coreos.oem.id) == "ec2" ]]; then
+    #if [[ $platform_id == "ec2" ]]; then
     #    mkdir -p ${UNIT_DIR}/systemd-networkd.service.d
     #    cat > ${UNIT_DIR}/systemd-networkd.service.d/10-conflict-emergency.conf <<EOF
 #[Unit]
@@ -86,7 +89,7 @@ if [ -n "$RANDOMIZE_DISK_GUID" ]; then
     add_requires "disk-uuid@${escaped_guid}.service"
 fi
 
-if [[ $(cmdline_arg coreos.oem.id) == "digitalocean" ]]; then
+if [[ $platform_id == "digitalocean" ]]; then
     add_requires coreos-digitalocean-network.service
 fi
 
@@ -95,4 +98,4 @@ if [[ $(systemd-detect-virt || true) =~ ^(kvm|qemu)$ ]]; then
     oem_id=qemu
 fi
 
-echo "OEM_ID=$(cmdline_arg coreos.oem.id ${oem_id})" > /run/ignition.env
+echo "PLATFORM_ID=$platform_id" > /run/ignition.env

--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -15,8 +15,8 @@ destination=/usr/lib/ignition/
 mkdir -p $destination
 
 # We will support grabbing a platform specific base.ign config
-# from the initrd at /usr/lib/ignition/platform/${OEM_ID}/base.ign
-copy_file_if_exists "/usr/lib/ignition/platform/${OEM_ID}/base.ign" "${destination}/base.ign"
+# from the initrd at /usr/lib/ignition/platform/${PLATFORM_ID}/base.ign
+copy_file_if_exists "/usr/lib/ignition/platform/${PLATFORM_ID}/base.ign" "${destination}/base.ign"
 
 # We will support a user embedded config in the boot partition
 # under $bootmnt/ignition/config.ign. Note that we mount /boot


### PR DESCRIPTION
With https://github.com/coreos/ignition/pull/735 merged, we need to fix
our service units to use `--platform` here. Also just do the equivalent
thing here and start to move away from the oem terminology. Crucially
though, we still look for `coreos.oem.id` until downstreams have
adapted (notably coreos-assembler).