### PR TITLE
module-setup.sh: Simplify the qemu_fw_cfg kernel module check

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -57,15 +57,15 @@ install() {
 #       "$systemdsystemunitdir/coreos-static-network.service"
 }
 
-has_builtin_fw_cfg() {
-    # this is like check_kernel_config() but it specifically checks for `y` and
+has_fw_cfg_module() {
+    # this is like check_kernel_config() but it specifically checks for `m` and
     # also checks the OSTree-specific kernel location
     for path in /boot/config-$kernel \
                 /usr/lib/modules/$kernel/config \
                 /usr/lib/ostree-boot/config-$kernel; do
         if test -f $path; then
             rc=0
-            grep -q CONFIG_FW_CFG_SYSFS=y $path || rc=$?
+            grep -q CONFIG_FW_CFG_SYSFS=m $path || rc=$?
             return $rc
         fi
     done
@@ -74,7 +74,8 @@ has_builtin_fw_cfg() {
 
 installkernel() {
     # We definitely need this one in the initrd to support Ignition cfgs on qemu
-    if ! has_builtin_fw_cfg; then
+    # if available
+    if has_fw_cfg_module; then
         instmods -c qemu_fw_cfg
     fi
 }


### PR DESCRIPTION
This fixes it on not supported arches(i.e. including module that doesn't exist). It will unblock the cosa on all arches that don't support the qemu_fw_cfg(related to the ignition [#666](https://github.com/coreos/ignition/issues/666)). I haven't yet tested this on x86_64. I would much appreciate testing on x86_64 and comments on the general approach.