### PR TITLE
WIP: systemd: add 2nd firstboot-complete service for UEFI

### DIFF
--- a/systemd/ignition-firstboot-complete-efi.service
+++ b/systemd/ignition-firstboot-complete-efi.service
@@ -2,9 +2,7 @@
 Description=Mark boot complete
 Documentation=https://github.com/coreos/ignition
 ConditionKernelCommandLine=ignition.firstboot
-RequiresMountsFor=/boot
-# on EFI systems the file is under /boot/efi/
-ConditionPathIsMountPoint=!/boot/efi
+RequiresMountsFor=/boot/efi
 
 [Service]
 Type=oneshot
@@ -19,7 +17,7 @@ RemainAfterExit=yes
 # detected this file. Fail if we are unable to remove it, rather than risking
 # rerunning Ignition at next boot.
 MountFlags=slave
-ExecStart=/bin/sh -c 'mount -o remount,rw /boot && rm /boot/ignition.firstboot'
+ExecStart=/bin/sh -c 'mount -o remount,rw /boot/efi && rm /boot/efi/ignition.firstboot'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We need a second firstboot-complete service to delete
the ignition.firstboot file that may be under /boot/efi
rather than /boot.

This is a bit of a hack workaround for now until we get a
better solution.

See https://github.com/coreos/coreos-assembler/issues/383