### PR TITLE
grub: find boot partition and use it directly

### DIFF
--- a/grub/02_ignition_firstboot
+++ b/grub/02_ignition_firstboot
@@ -1,7 +1,13 @@
 #!/bin/sh
 exec tail -n +3 $0
+# We store the file on the /boot/ partition so find the
+# boot partition. On UEFI this may different than the grub
+# $root so we search for it here.
+# https://github.com/coreos/ignition-dracut/issues/51
+search --set=bootpart --label boot
+# Determine if this is a first boot and set the variable
+# to be used later on the kernel command line.
 set ignition_firstboot=""
-# Determine if this is a first boot.
-if [ -f "/ignition.firstboot" ]; then
+if [ -f "(${bootpart})/ignition.firstboot" ]; then
     set ignition_firstboot="ignition.firstboot"
 fi


### PR DESCRIPTION
On UEFI systems the grub $root might be the /boot/efi/
partition and not the /boot/ partition so let's search
for the partition with the `boot` label and then detect
the file directly.

Fixes #51