### PR TITLE
Add ignition-complete.target

### DIFF
--- a/dracut/30ignition/ignition-ask-var-mount.service
+++ b/dracut/30ignition/ignition-ask-var-mount.service
@@ -9,6 +9,7 @@ Description=Ask OSTree to mount /var in initramfs
 DefaultDependencies=false
 After=basic.target
 Before=ostree-prepare-root.service
+Before=ignition-complete.target
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-complete.target
+++ b/dracut/30ignition/ignition-complete.target
@@ -1,0 +1,15 @@
+# This target is reached when Ignition finishes running. Note that it gets
+# activated *only* on first boot (or if ignition.firstboot=1 is provided).
+# Thus, it is also an API for units to use so that they are activated only on
+# first boot. Simply add a link under ignition-complete.target.requires in the
+# initrd.
+[Unit]
+Description=Ignition Complete
+
+# Make sure we stop all the units before switching root
+Conflicts=initrd-switch-root.target umount.target
+Conflicts=dracut-emergency.service emergency.service emergency.target
+
+# This ensures that we fail the boot if the stopping units fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate

--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Ignition (disks)
 DefaultDependencies=false
+Before=ignition-complete.target
 
 # This stage runs between `basic.target` and `initrd-root-fs.target`,
 # see https://www.freedesktop.org/software/systemd/man/bootup.html
@@ -12,9 +13,8 @@ After=basic.target
 Before=initrd-root-fs.target
 Before=sysroot.mount
 
-# Require and run after ignition-setup has run because ignition-setup
+# Run after ignition-setup has run because ignition-setup
 # may copy in new/different ignition configs for us to consume.
-Requires=ignition-setup.service
 After=ignition-setup.service
 
 # Network may be used to fetch userdata content.

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -1,18 +1,17 @@
 [Unit]
 Description=Ignition (files)
 DefaultDependencies=false
+Before=ignition-complete.target
 
 # Ignition files stage starts after /sysroot is mounted.
 Requires=initrd-root-fs.target
 After=initrd-root-fs.target
 
-# Require and run after ignition-setup has run because ignition-setup
+# Run after ignition-setup has run because ignition-setup
 # may copy in new/different ignition configs for us to consume.
-Requires=ignition-setup.service
 After=ignition-setup.service
 
 # Make sure root filesystem is mounted read-write
-Requires=ignition-remount-sysroot.service
 After=ignition-remount-sysroot.service
 
 # Run before initrd-parse-etc so that we can drop files it then picks up.

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -39,9 +39,7 @@ add_requires() {
 # starts the unit's dependencies. We want to start networking only on first
 # boot.
 if $(cmdline_bool 'ignition.firstboot' 0); then
-    add_requires ignition-disks.service
-    add_requires ignition-files.service
-    add_requires ignition-ask-var-mount.service
+    add_requires ignition-complete.target
 fi
 
 RANDOMIZE_DISK_GUID=$(cmdline_arg coreos.randomize_disk_guid)

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -42,30 +42,6 @@ if $(cmdline_bool 'ignition.firstboot' 0); then
     add_requires ignition-disks.service
     add_requires ignition-files.service
     add_requires ignition-ask-var-mount.service
-
-    # Write ignition-setup.service customized for PXE/ISO or regular boot
-    cat > ${UNIT_DIR}/ignition-setup.service <<EOF
-[Unit]
-Description=Ignition (setup)
-DefaultDependencies=false
-
-Requires=local-fs-pre.target
-Before=local-fs-pre.target
-Before=ignition-disks.service
-Before=ignition-files.service
-
-Requires=dev-disk-by\x2dlabel-boot.device
-After=dev-disk-by\x2dlabel-boot.device
-
-[Service]
-Type=oneshot
-RemainAfterExit=yes
-EnvironmentFile=/run/ignition.env
-# The MountFlags=slave is so the umount of /boot is guaranteed to happen
-# /boot will only be mounted for the lifetime of the unit.
-MountFlags=slave
-ExecStart=/usr/sbin/ignition-setup
-EOF
 fi
 
 RANDOMIZE_DISK_GUID=$(cmdline_arg coreos.randomize_disk_guid)

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -5,6 +5,7 @@ Description=Remount /sysroot read-write for Ignition
 # this case, remount /sysroot to rw (issue #37)
 DefaultDependencies=no
 After=sysroot.mount
+Before=ignition-complete.target
 ConditionPathIsReadWrite=!/sysroot
 
 [Service]

--- a/dracut/30ignition/ignition-setup.service
+++ b/dracut/30ignition/ignition-setup.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Ignition (setup)
+DefaultDependencies=false
+
+Requires=local-fs-pre.target
+Before=local-fs-pre.target
+Before=ignition-disks.service
+Before=ignition-files.service
+
+Requires=dev-disk-by\x2dlabel-boot.device
+After=dev-disk-by\x2dlabel-boot.device
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/run/ignition.env
+# The MountFlags=slave is so the umount of /boot is guaranteed to happen
+# /boot will only be mounted for the lifetime of the unit.
+MountFlags=slave
+ExecStart=/usr/sbin/ignition-setup

--- a/dracut/30ignition/ignition-setup.service
+++ b/dracut/30ignition/ignition-setup.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Ignition (setup)
 DefaultDependencies=false
+Before=ignition-complete.target
 
 Requires=local-fs-pre.target
 Before=local-fs-pre.target

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -6,6 +6,12 @@ depends() {
     echo qemu systemd url-lib network
 }
 
+install_ignition_unit() {
+    unit=$1; shift
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    ln_r "../$unit" "$systemdsystemunitdir/ignition-complete.target.requires/$unit"
+}
+
 install() {
     inst_multiple \
         chroot \
@@ -32,20 +38,16 @@ install() {
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
 
-    inst_simple "$moddir/ignition-setup.service" \
-        "$systemdsystemunitdir/ignition-setup.service"
+    inst_simple "$moddir/ignition-complete.target" \
+        "$systemdsystemunitdir/ignition-complete.target"
 
-    inst_simple "$moddir/ignition-disks.service" \
-        "$systemdsystemunitdir/ignition-disks.service"
+    mkdir -p "$initdir/$systemdsystemunitdir/ignition-complete.target.requires"
 
-    inst_simple "$moddir/ignition-files.service" \
-        "$systemdsystemunitdir/ignition-files.service"
-
-    inst_simple "$moddir/ignition-ask-var-mount.service" \
-        "$systemdsystemunitdir/ignition-ask-var-mount.service"
-
-    inst_simple "$moddir/ignition-remount-sysroot.service" \
-        "$systemdutildir/system/ignition-remount-sysroot.service"
+    install_ignition_unit ignition-setup.service
+    install_ignition_unit ignition-disks.service
+    install_ignition_unit ignition-files.service
+    install_ignition_unit ignition-ask-var-mount.service
+    install_ignition_unit ignition-remount-sysroot.service
 }
 
 has_fw_cfg_module() {

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -32,6 +32,9 @@ install() {
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
 
+    inst_simple "$moddir/ignition-setup.service" \
+        "$systemdsystemunitdir/ignition-setup.service"
+
     inst_simple "$moddir/ignition-disks.service" \
         "$systemdsystemunitdir/ignition-disks.service"
 


### PR DESCRIPTION
From the comment block of the unit:

    This target is reached when Ignition finishes running. Note that it
    gets activated *only* on first boot (or if ignition.firstboot=1 is
    provided).  Thus, it is also an API for units to use so that they
    are activated only on first boot. Simply add a link under
    ignition-complete.target.requires in the initrd.

Thus, units themselves don't need to add explicit `Requires=`; the
canonical way to get pulled into the transaction is through
`ignition-complete.target`.

This will also be used by the upcoming CoreOS units that are required
for separate `/var` support.