### PR TITLE
dracut/30ignition: expect ignition binary in module directory

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -17,7 +17,6 @@ install() {
         chroot \
         groupadd \
         id \
-        ignition \
         mkfs.ext4 \
         mkfs.vfat \
         mkfs.xfs \
@@ -34,6 +33,11 @@ install() {
 
     inst_script "$moddir/ignition-setup.sh" \
         "/usr/sbin/ignition-setup"
+
+    # Distro packaging is expected to install the ignition binary into the
+    # module directory.
+    inst_simple "$moddir/ignition" \
+        "/usr/bin/ignition"
 
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"


### PR DESCRIPTION
The `ignition` binary is not intended to be run by users or in the real root filesystem, and thus should never be in PATH.  Expect distros to install it into the dracut module directory instead.