### PR TITLE
02_ignition_firstboot: Enable networking if Ignition will run

### DIFF
--- a/grub/02_ignition_firstboot
+++ b/grub/02_ignition_firstboot
@@ -9,5 +9,5 @@ search --set=bootpart --label boot
 # to be used later on the kernel command line.
 set ignition_firstboot=""
 if [ -f "(${bootpart})/ignition.firstboot" ]; then
-    set ignition_firstboot="ignition.firstboot"
+    set ignition_firstboot="ignition.firstboot rd.neednet=1 ip=dhcp"
 fi


### PR DESCRIPTION
Today coreos-assembler is hardcoding the initramfs networking kargs to
do DHCP; this is problematic for e.g. bare metal where one often wants
to configure static networking.

Let's only enable initramfs networking if we're doing Ignition.