### PR TITLE
spec2x: backports from master branch

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -11,7 +11,6 @@ install() {
         chroot \
         groupadd \
         id \
-        ignition \
         mkfs.ext4 \
         mkfs.vfat \
         mkfs.xfs \
@@ -31,6 +30,11 @@ install() {
 
 #   inst_script "$moddir/retry-umount.sh" \
 #       "/usr/sbin/retry-umount"
+
+    # Distro packaging is expected to install the ignition binary into the
+    # module directory.
+    inst_simple "$moddir/ignition" \
+        "/usr/bin/ignition"
 
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -57,15 +57,15 @@ install() {
 #       "$systemdsystemunitdir/coreos-static-network.service"
 }
 
-has_builtin_fw_cfg() {
-    # this is like check_kernel_config() but it specifically checks for `y` and
+has_fw_cfg_module() {
+    # this is like check_kernel_config() but it specifically checks for `m` and
     # also checks the OSTree-specific kernel location
     for path in /boot/config-$kernel \
                 /usr/lib/modules/$kernel/config \
                 /usr/lib/ostree-boot/config-$kernel; do
         if test -f $path; then
             rc=0
-            grep -q CONFIG_FW_CFG_SYSFS=y $path || rc=$?
+            grep -q CONFIG_FW_CFG_SYSFS=m $path || rc=$?
             return $rc
         fi
     done
@@ -74,7 +74,8 @@ has_builtin_fw_cfg() {
 
 installkernel() {
     # We definitely need this one in the initrd to support Ignition cfgs on qemu
-    if ! has_builtin_fw_cfg; then
+    # if available
+    if has_fw_cfg_module; then
         instmods -c qemu_fw_cfg
     fi
 }

--- a/grub/02_ignition_firstboot
+++ b/grub/02_ignition_firstboot
@@ -1,7 +1,13 @@
 #!/bin/sh
 exec tail -n +3 $0
+# We store the file on the /boot/ partition so find the
+# boot partition. On UEFI this may different than the grub
+# $root so we search for it here.
+# https://github.com/coreos/ignition-dracut/issues/51
+search --set=bootpart --label boot
+# Determine if this is a first boot and set the variable
+# to be used later on the kernel command line.
 set ignition_firstboot=""
-# Determine if this is a first boot.
-if [ -f "/ignition.firstboot" ]; then
+if [ -f "(${bootpart})/ignition.firstboot" ]; then
     set ignition_firstboot="ignition.firstboot"
 fi

--- a/grub/02_ignition_firstboot
+++ b/grub/02_ignition_firstboot
@@ -9,5 +9,5 @@ search --set=bootpart --label boot
 # to be used later on the kernel command line.
 set ignition_firstboot=""
 if [ -f "(${bootpart})/ignition.firstboot" ]; then
-    set ignition_firstboot="ignition.firstboot"
+    set ignition_firstboot="ignition.firstboot rd.neednet=1 ip=dhcp"
 fi


### PR DESCRIPTION
This PR contains backports of the following patches in master:

- 738c676 dracut/30ignition: expect ignition binary in module directory
-  c62a108 02_ignition_firstboot: Enable networking if Ignition will run
- 552edb5 grub: find boot partition and use it directly
- 819e0da module-setup.sh: Check for module qemu_fw_cfg not build-in, so it works out of box on all arches