### PR TITLE
spec2x: dracut/30ignition: order services before initrd.target 

### DIFF
--- a/dracut/30ignition/ignition-ask-var-mount.service
+++ b/dracut/30ignition/ignition-ask-var-mount.service
@@ -7,8 +7,13 @@
 [Unit]
 Description=Ask OSTree to mount /var in initramfs
 DefaultDependencies=false
+Before=initrd.target
 After=basic.target
 Before=ostree-prepare-root.service
+
+# Make sure if ExecStart= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=Ignition (disks)
 DefaultDependencies=false
+Before=initrd.target
+
+# Make sure if ExecStart= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 # This stage runs between `basic.target` and `initrd-root-fs.target`,
 # see https://www.freedesktop.org/software/systemd/man/bootup.html

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=Ignition (files)
 DefaultDependencies=false
+Before=initrd.target
+
+# Make sure if ExecStart= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 # Ignition files stage starts after /sysroot is mounted.
 Requires=initrd-root-fs.target

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -61,6 +61,11 @@ cat > ${UNIT_DIR}/ignition-setup.service <<EOF
 [Unit]
 Description=Ignition (setup)
 DefaultDependencies=false
+Before=initrd.target
+
+# Make sure if ExecStart= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 Requires=local-fs-pre.target
 Before=local-fs-pre.target

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -4,8 +4,13 @@ Description=Remount /sysroot read-write for Ignition
 # commandline and thus mount the root filesystem ro by default. In
 # this case, remount /sysroot to rw (issue #37)
 DefaultDependencies=no
+Before=initrd.target
 After=sysroot.mount
 ConditionPathIsReadWrite=!/sysroot
+
+# Make sure if ExecStart= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Backport of 50d1830.

But we don't have an `ignition-complete.target` here so just add it to
each individual service. Super tempted to just backport everything from
master and just leave off the spec 3.0.0 specific bits, though let's do
the least invasive fix for now.

Note here that we have to add `OnFailureJobMode=isolate` because
otherwise the boot will just keep looping around for a while instead of
crashing:

https://bugzilla.redhat.com/show_bug.cgi?id=1696796

Closes: #59