### PR TITLE
dracut/30ignition: Explicitly add OnFailure=emergency.target

### DIFF
--- a/dracut/30ignition/ignition-ask-var-mount.service
+++ b/dracut/30ignition/ignition-ask-var-mount.service
@@ -10,6 +10,8 @@ DefaultDependencies=false
 After=basic.target
 Before=ostree-prepare-root.service
 Before=ignition-complete.target
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-complete.target
+++ b/dracut/30ignition/ignition-complete.target
@@ -5,11 +5,9 @@
 # initrd.
 [Unit]
 Description=Ignition Complete
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 # Make sure we stop all the units before switching root
 Conflicts=initrd-switch-root.target umount.target
 Conflicts=dracut-emergency.service emergency.service emergency.target
-
-# This ensures that we fail the boot if the stopping units fails
-OnFailure=emergency.target
-OnFailureJobMode=isolate

--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -2,6 +2,8 @@
 Description=Ignition (disks)
 DefaultDependencies=false
 Before=ignition-complete.target
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 # This stage runs between `basic.target` and `initrd-root-fs.target`,
 # see https://www.freedesktop.org/software/systemd/man/bootup.html

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -2,6 +2,8 @@
 Description=Ignition (files)
 DefaultDependencies=false
 Before=ignition-complete.target
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 # Ignition files stage starts after /sysroot is mounted.
 Requires=initrd-root-fs.target

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -7,6 +7,8 @@ DefaultDependencies=no
 After=sysroot.mount
 Before=ignition-complete.target
 ConditionPathIsReadWrite=!/sysroot
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-setup.service
+++ b/dracut/30ignition/ignition-setup.service
@@ -2,6 +2,8 @@
 Description=Ignition (setup)
 DefaultDependencies=false
 Before=ignition-complete.target
+OnFailure=emergency.target
+OnFailureJobMode=isolate
 
 Requires=local-fs-pre.target
 Before=local-fs-pre.target


### PR DESCRIPTION
Right now, we enable our services by adding a link in
`initrd.target.requires`. However, it seems like systemd doesn't
necessarily fail the boot even if `initrd.target` fails. That unit has:

    OnFailure=emergency.target
    OnFailureJobMode=replace-irreversibly

But looking at the logs, it seems like that can get overridden by the
`systemctl isolate initrd-switch-root.target` call that
`initrd-cleanup.service` does.

Let's just be really explicit here and tell systemd we want to
immediately switch to `emergency.target` if any of our units fail.