### PR TITLE
spec2x: grub: support overriding network kcmdline args

### DIFF
--- a/grub/02_ignition_firstboot
+++ b/grub/02_ignition_firstboot
@@ -9,5 +9,16 @@ search --set=bootpart --label boot
 # to be used later on the kernel command line.
 set ignition_firstboot=""
 if [ -f "(${bootpart})/ignition.firstboot" ]; then
-    set ignition_firstboot="ignition.firstboot rd.neednet=1 ip=dhcp"
+    # default to dhcp networking parameters to be used with ignition 
+    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp'
+
+    # source in the `ignition.firstboot` file which could override the
+    # above $ignition_network_kcmdline with static networking config.
+    # This override feature is primarily used by coreos-installer to
+    # persist static networking config provided during install to the    
+    # first boot of the machine.
+    source "(${bootpart})/ignition.firstboot"
+    
+    # we support setting variables in the 
+    set ignition_firstboot="ignition.firstboot $ignition_network_kcmdline"
 fi


### PR DESCRIPTION
This allows us to set network kcmdline args by setting the
ignition_network_kcmdline variable inside the ignition.firstboot
file that resides on the /boot/ filesystem and triggers ignition
run on boot.

This functionality will allow the coreos-installer to promote static
networking arguments that were used during the installer run to the
first boot of the real system. After that they are no longer needed
as ignition can configure networking as requested by the user.

(cherry picked from commit a65ec1667338518a44c75a21ceb955408c3061da)