### PR TITLE
module_setup: include cdrom rules for openstack

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -62,6 +62,9 @@ install() {
     install_ignition_unit coreos-populate-var.service
     inst_script "$moddir/coreos-populate-var.sh" \
         "/usr/sbin/coreos-populate-var"
+
+    # needed for openstack config drive support
+    inst_rules 60-cdrom_id.rules
 }
 
 has_fw_cfg_module() {


### PR DESCRIPTION
The Ignition openstack platform needs to be able to read from a virtual
cdrom and needs to include the uedv rules to create the symlink. Add
those rules.