### PR TITLE
[spec2x] module_setup: include cdrom rules for openstack

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -59,6 +59,9 @@ install() {
 
 #   inst_simple "$moddir/coreos-static-network.service" \
 #       "$systemdsystemunitdir/coreos-static-network.service"
+
+    # needed for openstack config drive support
+    inst_rules 60-cdrom_id.rules
 }
 
 has_fw_cfg_module() {


### PR DESCRIPTION
The Ignition openstack platform needs to be able to read from a virtual
cdrom and needs to include the uedv rules to create the symlink. Add
those rules.