### PR TITLE
dracut/30ignition: link to RHBZ in ignition-complete

### DIFF
--- a/dracut/30ignition/ignition-complete.target
+++ b/dracut/30ignition/ignition-complete.target
@@ -7,7 +7,9 @@
 Description=Ignition Complete
 Before=initrd.target
 
-# Make sure if any ExecStart= fail, the boot fails
+# Make sure if any ExecStart= fail, the boot fails. This normally would
+# already be guaranteed by `initrd.target` failing, but that doesn't seem to be
+# enough: https://bugzilla.redhat.com/show_bug.cgi?id=1696796
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 


### PR DESCRIPTION
We shouldn't actually need to do `OnFailure=emergency.target` in
`ignition-complete.service` here. Our unit is already a requirement of
`initrd.target`, and so once we fail, `initrd.target` should fail, which
in turn should trigger *its* `OnFailure=emergency.target`.

However, this doesn't work in f29/el8:
https://bugzilla.redhat.com/show_bug.cgi?id=1696796

Add a comment about that.

See also: https://github.com/coreos/ignition-dracut/pull/61/#issuecomment-475767503