### PR TITLE
ignition-files: always relabel /var on first boot

### DIFF
--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -34,3 +34,10 @@ After=ignition-disks.service
 Type=oneshot
 EnvironmentFile=/run/ignition.env
 ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=files --log-to-stdout
+# Hack to just always relabel /var on first boot. This is run by
+# systemd-tmpfiles shortly after mounting things, so there isn't a lot of data
+# yet in it. See https://bugzilla.redhat.com/show_bug.cgi?id=1699107. Ideally,
+# systemd would learn to do this at mount time to avoid race conditions. See:
+# https://github.com/systemd/systemd/pull/11903
+ExecStart=/usr/bin/mkdir -p /run/tmpfiles.d
+ExecStart=/usr/bin/sh -c "echo 'Z /var - - -' > /run/tmpfiles.d/var-relabel.conf"


### PR DESCRIPTION
This is in spirit a backport of [1]. But it's as relevant on the spec2x
branch.

[1] https://github.com/coreos/ignition-dracut/blob/85f2e6558c5e1651e2934849b8ad1d74a5c7ad74/dracut/30ignition/coreos-populate-var.sh#L36