### PR TITLE
WIP: 30ignition: remove initramfs networking

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs-network.service
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.service
@@ -1,0 +1,20 @@
+# Clean up the initramfs networking on first boot
+# so the real network is being brought up
+
+[Unit]
+Description=Tear down initramfs networking
+DefaultDependencies=false
+After=ignition-files.service
+
+# Make sure ExecStop= runs before we switch root
+Conflicts=initrd-switch-root.target umount.target
+Before=initrd-switch-root.target
+
+# Make sure if ExecStart= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/sbin/coreos-teardown-initramfs-network

--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+set -euo pipefail
+
+# Clean up the interfaces set up in the initramfs
+# This mimics the behaviour of dracut's ifdown() in net-lib.sh
+if ! [ -z "$(ls /sys/class/net)" ]; then
+    for f in /sys/class/net/*; do
+        interface=$(basename "$f")
+        ip link set $interface down
+        ip addr flush dev $interface
+        rm -f -- /tmp/net.$interface.did-setup
+    done
+fi

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -63,6 +63,10 @@ install() {
     inst_script "$moddir/coreos-populate-var.sh" \
         "/usr/sbin/coreos-populate-var"
 
+    install_ignition_unit coreos-teardown-initramfs-network.service
+    inst_script "$moddir/coreos-teardown-initramfs-network.sh" \
+	"/usr/bin/coreos-teardown-initramfs-network"
+
     # needed for openstack config drive support
     inst_rules 60-cdrom_id.rules
 }


### PR DESCRIPTION
Add coreos-remove-initramfs-network.service to run after ignition
has finished using initramfs networking, so NetworkManager properly
brings up ignition-configured networking in the real root. Otherwise
the initramfs network persists into the real root.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>