### PR TITLE
dracut/30ignition: backport coreos-populate-var

### DIFF
--- a/dracut/30ignition/coreos-populate-var.sh
+++ b/dracut/30ignition/coreos-populate-var.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if [ $# -ne 0 ]; then
+    fatal "Usage: $0"
+fi
+
+### NOTE: Since spec 2 doesn't support mount stages, we might in fact end up
+### creating things under /var that end up being shadowed. This is essentially a
+### best effort here.
+
+# See the similar code block in Anaconda, which handles this today for Atomic
+# Host and Silverblue:
+# https://github.com/rhinstaller/anaconda/blob/b9ea8ce4e68196b30a524c1cc5680dcdc4b89371/pyanaconda/payload/rpmostreepayload.py#L332
+
+# Simply manually mkdir /var/lib; the tmpfiles.d entries otherwise reference
+# users/groups which we don't have access to from here (though... we *could*
+# import them from the sysroot, and have nss-altfiles in the initrd, but meh...
+# let's just wait for systemd-sysusers which will make this way easier:
+# https://github.com/coreos/fedora-coreos-config/pull/56/files#r262592361).
+mkdir -p /sysroot/var/lib
+
+systemd-tmpfiles --create --boot --root=/sysroot \
+    --prefix=/var/home \
+    --prefix=/var/roothome \
+    --prefix=/var/opt \
+    --prefix=/var/srv \
+    --prefix=/var/usrlocal \
+    --prefix=/var/mnt \
+    --prefix=/var/media
+
+# Ask for /var to be relabeled.
+# See also: https://github.com/coreos/ignition/issues/635.
+mkdir -p /run/tmpfiles.d
+echo "Z /var - - -" > /run/tmpfiles.d/var-relabel.conf
+
+# XXX: https://github.com/systemd/systemd/pull/11903
+# XXX: fix root-bash-profile and drop from here
+for unit in systemd-{journal-catalog-update,random-seed}.service \
+            coreos-root-bash-profile-workaround.service; do
+    mkdir -p /run/systemd/system/${unit}.d
+    cat > /run/systemd/system/${unit}.d/after-tmpfiles.conf <<EOF
+[Unit]
+After=systemd-tmpfiles-setup.service
+EOF
+done

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -33,11 +33,5 @@ After=ignition-disks.service
 [Service]
 Type=oneshot
 EnvironmentFile=/run/ignition.env
+ExecStart=/usr/bin/coreos-populate-var
 ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=files --log-to-stdout
-# Hack to just always relabel /var on first boot. This is run by
-# systemd-tmpfiles shortly after mounting things, so there isn't a lot of data
-# yet in it. See https://bugzilla.redhat.com/show_bug.cgi?id=1699107. Ideally,
-# systemd would learn to do this at mount time to avoid race conditions. See:
-# https://github.com/systemd/systemd/pull/11903
-ExecStart=/usr/bin/mkdir -p /run/tmpfiles.d
-ExecStart=/usr/bin/sh -c "echo 'Z /var - - -' > /run/tmpfiles.d/var-relabel.conf"

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -36,6 +36,9 @@ install() {
     inst_simple "$moddir/ignition" \
         "/usr/bin/ignition"
 
+    inst_simple "$moddir/coreos-populate-var.sh" \
+        "/usr/bin/coreos-populate-var"
+
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
 


### PR DESCRIPTION
Although spec 2 doesn't support all the mount points, we still need to
populate `/var` as we do on FCOS so that e.g. `useradd` will work. We've
missed this til now because we weren't actually fully emptying `/var` in
the images: https://github.com/coreos/coreos-assembler/pull/494

Resolves: https://github.com/coreos/coreos-assembler/issues/500