### PR TITLE
[PoC][don't-merge]dracut/30ignition: allow to extend the cmdline via ign file

### DIFF
--- a/dracut/30ignition/ignition-cmdline.sh
+++ b/dracut/30ignition/ignition-cmdline.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+type getarg >/dev/null 2>&1 || . /lib/dracut-lib.sh
+getargbool 0 ignition.firstboot || exit 0
+
+ign_file="/sys/firmware/qemu_fw_cfg/by_name/opt/com.coreos/config/raw"
+[ -e "$ign_file" ] || exit 0
+
+opt_cmdline=$(jq -r '{dracut: .dracut.cmdline} | .[]' "$ign_file")
+[ -n "$opt_cmdline" ] && echo "$opt_cmdline" > /etc/cmdline.d/ignition-cmdline.conf
+
+exit 0

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -27,7 +27,8 @@ install() {
         useradd \
         usermod \
         realpath \
-        touch
+        touch \
+        jq
 
     # This one is optional; https://src.fedoraproject.org/rpms/ignition/pull-request/9
     inst_multiple -o mkfs.btrfs
@@ -56,6 +57,8 @@ install() {
 
     # needed for openstack config drive support
     inst_rules 60-cdrom_id.rules
+
+    inst_hook cmdline 00 "$moddir/ignition-cmdline.sh"
 }
 
 has_fw_cfg_module() {


### PR DESCRIPTION
When I was playing with RHCOS, I have noticed, that ignition always user rd.neednet=1 ip=dhcp, which cause that Dracut scripts start the dhclient on the device. And if a user tries to create the ifcfg files with the static configuration it leads to problems described in https://bugzilla.redhat.com/show_bug.cgi?id=169342.
The current solution to the mentioned Bugzilla is to tear down the network at the end of initrd, which is ugly as hell.

My proposal would be to use the Dracut infrastructure here and always use its ip= option. Dracut will not just set up the specified network, but also create matching ifcfg files that can be just copied to /etc/ on the normal host (they are in /run/initramfs/state/etc/sysconfig/network-scripts/ both in initrd and in the normal system).

I would assume that users would hate to modify the actual kernel cmdline so I would suggest using ignition configuration files to extend the cmdline (see the commit itself):
```
...
    "dracut": {
        "cmdline": "rd.neednet=1 ip=192.168.2.2::192.168.2.1:255.255.255.0:name:ens3:none"
    }
...
```
With this dracut will set up the network and create following ifcfg file:
```
# Generated by dracut initrd
NAME="ens3"
DEVICE="ens3"
ONBOOT=yes
NETBOOT=yes
UUID="0edb2f00-1921-46c9-9e23-d4f2cbe41f49"
BOOTPROTO=none
IPADDR="192.168.2.2"
NETMASK="255.255.255.0"
GATEWAY="192.168.2.1"
TYPE=Ethernet
```

To use the configuration in the real system you could just copy this unit-file and script from initscripts package:
https://github.com/fedora-sysv/initscripts/blob/master/usr/lib/systemd/system/import-state.service
https://github.com/fedora-sysv/initscripts/blob/master/usr/libexec/import-state



 