### PR TITLE
dracut: add 99emergency-timeout

### DIFF
--- a/dracut/99emergency-timeout/module-setup.sh
+++ b/dracut/99emergency-timeout/module-setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+install() {
+    inst_multiple \
+        cut \
+        date
+
+    inst_hook emergency 99 "${moddir}/timeout.sh"
+}

--- a/dracut/99emergency-timeout/timeout.sh
+++ b/dracut/99emergency-timeout/timeout.sh
@@ -1,0 +1,90 @@
+# Before starting the emergency shell, prompt the user to press Enter.
+# If they don't, reboot the system.
+#
+# Assumes /bin/sh is bash.
+
+# _wait_for_journalctl_to_stop will block until either:
+# - no messages have appeared in journalctl for the past 5 seconds
+# - 15 seconds have elapsed
+_wait_for_journalctl_to_stop() {
+    local time_since_last_log=0
+
+    local time_started="$(date '+%s')"
+    local now="$(date '+%s')"
+
+    while [ ${time_since_last_log} -lt 5 -a $((now-time_started)) -lt 15 ]; do
+        sleep 1
+
+        local last_log_timestamp="$(journalctl -e -n 1 -q -o short-unix | cut -d '.' -f 1)"
+        local now="$(date '+%s')"
+
+        local time_since_last_log=$((now-last_log_timestamp))
+    done
+}
+
+_prompt_for_timeout() {
+    local timeout=300
+    local interval=15
+
+    if [[ -e /.emergency-shell-confirmed ]]; then
+        return
+    fi
+    ignition_units="ignition-disks.service ignition-files.service ignition-mount.service"
+    if systemctl show $ignition_units | grep -q "^ActiveState=failed$"; then
+        # Ignition has failed, suppress kernel logs so that Ignition logs stay
+        # on the screen
+        dmesg --console-off
+
+        # There's a couple straggler systemd messages. Wait until it's been 5
+        # seconds since something was written to the journal.
+        _wait_for_journalctl_to_stop
+
+        # Print Ignition logs
+        cat <<EOF
+-------------------------------------------------------------------------------
+Ignition has failed. Please ensure your config is valid. Note that only Ignition spec
+v3.0.0+ configs are accepted.
+A CLI validation tool to check this called ignition-validate can be downloaded from GitHub:
+    https://github.com/coreos/ignition/releases
+Here are the Ignition logs:
+EOF
+        journalctl -t ignition --no-pager --no-hostname -o cat
+    fi
+
+    # Regularly prompt with time remaining.  This ensures the prompt doesn't
+    # get lost among kernel and systemd messages, and makes it clear what's
+    # going on if the user just connected a serial console.
+    while [[ $timeout > 0 ]]; do
+        local m=$(( $timeout / 60 ))
+        local s=$(( $timeout % 60 ))
+        local m_label="minutes"
+        if [[ $m = 1 ]]; then
+            m_label="minute"
+        fi
+
+        if [[ $s != 0 ]]; then
+            echo -n -e "Press Enter for emergency shell or wait $m $m_label $s seconds for reboot.      \r"
+        else
+            echo -n -e "Press Enter for emergency shell or wait $m $m_label for reboot.                 \r"
+        fi
+
+        local anything
+        if read -t $interval anything; then
+            > /.emergency-shell-confirmed
+            return
+        fi
+        timeout=$(( $timeout - $interval ))
+    done
+
+    echo -e "\nRebooting."
+    # This is not very nice, but since reboot.target likely conflicts with
+    # the existing goal target wrt the desired state of shutdown.target,
+    # there doesn't seem to be a better option.
+    systemctl reboot --force
+    exit 0
+}
+
+# If we're invoked from a dracut breakpoint rather than
+# dracut-emergency.service, we won't have a controlling terminal and stdio
+# won't be connected to it. Explicitly read/write /dev/console.
+_prompt_for_timeout < /dev/console > /dev/console


### PR DESCRIPTION
If Ignition fails, instead of immediately dropping to an emergency
shell, output a message indicating that Ignition failed and point
to ignition-validate. Offer to drop to an emergency shell if the
user presses Enter. If the user doesn't respond in 5 minutes,
reboot to try again. While waiting for the timeout, keep updating
the prompt with the time remaining until reboot.

Brought forward from the `99emergency-timeout` dracut module
present in Container Linux: https://github.com/coreos/bootengine/tree/c691205c0046e3828a8536d553aea7307ca3abee/dracut/99emergency-timeout

Closes: #35

---

Minor tweaks were made to the output message:

```diff
diff --git a/bootengine/dracut/99emergency-timeout/timeout.sh b/ignition-dracut/dracut/99emergency-timeout/timeout.sh
index c37bd7b..b678368 100644
--- a/bootengine/dracut/99emergency-timeout/timeout.sh
+++ b/ignition-dracut/dracut/99emergency-timeout/timeout.sh
@@ -40,11 +40,11 @@ _prompt_for_timeout() {
         _wait_for_journalctl_to_stop
 
         # Print Ignition logs
-        cat <<EOF -------------------------------------------------------------------------------
+        cat <<EOF
+-------------------------------------------------------------------------------
 Ignition has failed. Please ensure your config is valid.
 A CLI validation tool for this called ignition-validate can be downloaded from GitHub:
     https://github.com/coreos/ignition/releases
-An online validator is also available at coreos.com/validate
 Here are the Ignition logs:
 EOF
         journalctl -t ignition --no-pager --no-hostname -o cat

```

Previous behavior in case of failure (drop immediately to emergency shell), with output trimmed:

```
[FAILED[    7.604600] ignition[728]: files failedFull config:

...
[    7.089746] systemd[1]: Startup finished in 1.509s (kernel) + 0 (initrd) + 5.383s (userspace) = 6.893s.

Generating "/run/initramfs/rdsosreport.txt"


Entering emergency mode. Exit the shell to continue.
Type "journalctl" to view system logs.
You might want to save "/run/initramfs/rdsosreport.txt" to a USB stick or /boot
after mounting them and attach it to a bug report.


:/# 
```

Behavior with this change (the `Please ensure your config is valid` message is printed):

<details>

```
[    6.646880] systemd[1]: Startup finished in 1.458s (kernel) + 0 (initrd) + 5.004s (userspace) = 6.463s.
-------------------------------------------------------------------------------
Ignition has failed. Please ensure your config is valid.
A CLI validation tool for this called ignition-validate can be downloaded from GitHub:
    https://github.com/coreos/ignition/releases
Here are the Ignition logs:
Ignition 2.0.0
reading system config file "/usr/lib/ignition/base.ign"
parsing config with SHA512: ff6a5153be363997e4d5d3ea8cc4048373a457c48c4a5b134a08a30aacd167c1e0f099f0bdf1e24c99ad180628cd02b767b863b5fe3a8fce3fe1886847eb8e2e
parsed url from cmdline: ""
no config URL provided
reading system config file "/usr/lib/ignition/user.ign"
no config at "/usr/lib/ignition/user.ign"
op(1): [started]  loading QEMU firmware config module
op(1): executing: "modprobe" "qemu_fw_cfg"
op(1): [finished] loading QEMU firmware config module
parsing config with SHA512: df5f6b322a19da581abd9aa4031fc02176929ee344c9bff40cf15e8d34d66ac85ee2325fc3de18ebb540a53ad4bd6a61d254a941f95741de13e9b6e0b30b9843
warning at $.storage.directories.0.mode, line 21 col 14: permissions unset, defaulting to 0755
warning at $.storage.directories.0.mode: permissions unset, defaulting to 0755
disks: disks passed
Ignition finished successfully
INFO     : Ignition 2.0.0
INFO     : reading system config file "/usr/lib/ignition/base.ign"
DEBUG    : parsing config with SHA512: ff6a5153be363997e4d5d3ea8cc4048373a457c48c4a5b134a08a30aacd167c1e0f099f0bdf1e24c99ad180628cd02b767b863b5fe3a8fce3fe1886847eb8e2e
INFO     : mount: mount passed
INFO     : Ignition finished successfully
INFO     : Ignition 2.0.0
INFO     : reading system config file "/usr/lib/ignition/base.ign"
DEBUG    : parsing config with SHA512: ff6a5153be363997e4d5d3ea8cc4048373a457c48c4a5b134a08a30aacd167c1e0f099f0bdf1e24c99ad180628cd02b767b863b5fe3a8fce3fe1886847eb8e2e
INFO     : files: createUsers: checking if user "core" exists: [Attention] exit status 1: Cmd: "chroot" "/sysroot" "id" "core" Stdout: id: ‘core’: no such user
INFO     : files: createUsers: op(1): [started]  creating or modifying user "core"
DEBUG    : files: createUsers: op(1): executing: "useradd" "--root" "/sysroot" "--create-home" "--password" "*" "--comment" "CoreOS Admin" "--groups" "adm,sudo,systemd-journal,wheel" "core"
INFO     : files: createUsers: op(1): [finished] creating or modifying user "core"
files failedFull config:
{
  "ignition": {
    "config": {
      "replace": {
        "source": null,
        "verification": {}
      }
    },
    "proxy": {},
    "security": {
      "tls": {}
    },
    "timeouts": {},
    "version": "3.1.0-experimental"
  },
  "passwd": {
    "users": [
      {
        "gecos": "CoreOS Admin",
        "groups": [
          "adm",
          "sudo",
          "systemd-journal",
          "wheel"
        ],
        "name": "core"
      }
    ]
  },
  "storage": {
    "directories": [
      {
        "group": {},
        "overwrite": false,
        "path": "/etc/issue",
        "user": {}
      }
    ],
    "files": [
      {
        "group": {},
        "path": "/etc/sysctl.d/10-coreos-assembler.conf",
        "user": {},
        "contents": {
          "source": "data:text/plain;base64,IyBXcml0dGVuIGR1cmluZyBgY29yZW9zLWFzc2VtYmxlciBydW5gLgoKIyBSaWdodCBub3csIHdlJ3JlIHJ1bm5pbmcgYXQgdGhlIGRlZmF1bHQgbG9nIGxldmVsLCB3aGljaCBpcyBERUJVRyAoNykuCiMgVGhlIHRleHQgZ2V0cyBpbnRlcnNwZXJzZWQgd,
          "verification": {}
        },
        "mode": 420
      },
      {
        "group": {},
        "path": "/etc/motd",
        "user": {},
        "append": [
          {
            "source": "data:text/plain;base64,SUNNUCB0cmFmZmljIChwaW5nKSBkb2VzIG5vdCB3b3JrIHdpdGggUUVNVSBhbmQgdXNlciBtb2RlIG5ldHdvcmtpbmcuClRvIGV4aXQsIHByZXNzIEN0cmwtQSBhbmQgdGhlbiBYLgoK",
            "verification": {}
          }
        ],
        "contents": {
          "verification": {}
        },
        "mode": 420
      }
    ]
  },
  "systemd": {
    "units": [
      {
        "dropins": [
          {
            "contents": "[Service]\nTTYVTDisallocate=no\nExecStart=\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM\n",
            "name": "autologin-core.conf"
          }
        ],
        "name": "serial-getty@ttyS0.service"
      }
    ]
  }
}CRITICAL : Ignition failed: failed to create files: failed to create files: error creating /sysroot/etc/issue: error creating directory /sysroot/etc/issue: A non-directory already exists and overwrite is false
INFO     : Ignition 2.0.0
INFO     : reading system config file "/usr/lib/ignition/base.ign"
DEBUG    : parsing config with SHA512: ff6a5153be363997e4d5d3ea8cc4048373a457c48c4a5b134a08a30aacd167c1e0f099f0bdf1e24c99ad180628cd02b767b863b5fe3a8fce3fe1886847eb8e2e
INFO     : umount: umount passed
INFO     : Ignition finished successfully
Press Enter for emergency shell or wait 5 minutes for reboot. 

```

</details>

Can be tested by installing an Ignition RPM from [COPR](https://copr.fedorainfracloud.org/coprs/rfairley/ignition/build/935612/) in FCOS (using `overrides/rpm` in `coreos-assembler`).