### PR TITLE
dracut/30ignition: Reboot the system after ignition if kargs.d is present

### DIFF
--- a/dracut/30ignition/ignition-apply-kargs.service
+++ b/dracut/30ignition/ignition-apply-kargs.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Reboot after Ignition to apply kargs
+Documentation=https://github.com/coreos/ignition-dracut
+DefaultDependencies=false
+Before=ignition-complete.target
+
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+# Make sure /sysroot/ostree/deploy/ is not empty
+Requires=ostree-prepare-root.service
+# Make sure /sysroot/etc/ostree/kargs.d exists if there are default kernel args
+After=ignition-files.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/ignition-apply-kargs

--- a/dracut/30ignition/ignition-apply-kargs.sh
+++ b/dracut/30ignition/ignition-apply-kargs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Reads default kernel arguments
+kargs=$(cat /sysroot/etc/ostree/kargs.d/karg_file)
+
+# Copied from ignition-generator
+cmdline_bool() {
+    local value=$(cmdline_arg "$@")
+    case "$value" in
+        ""|0|no|off) return 1;;
+        *) return 0;;
+    esac
+}
+
+# Checks if kernel argument directory exists,
+# then redeploy and reboot the system if it exists
+reboot_if_kargs_dir_exists() {
+    if [ -d /sysroot/etc/ostree/kargs.d ]; then
+        ostree admin instutil set-kargs -v --sysroot=/sysroot --merge ${kargs}
+        exec systemctl reboot
+    fi
+}
+
+if $(cmdline_bool 'ignition.firstboot' 0); then
+    reboot_if_kargs_dir_exists
+fi

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -27,13 +27,17 @@ install() {
         useradd \
         usermod \
         realpath \
-        touch
+        touch \
+        ostree
 
     # This one is optional; https://src.fedoraproject.org/rpms/ignition/pull-request/9
     inst_multiple -o mkfs.btrfs
 
     inst_script "$moddir/ignition-setup.sh" \
         "/usr/sbin/ignition-setup"
+
+    inst_script "$moddir/ignition-apply-kargs.sh" \
+        "/usr/sbin/ignition-apply-kargs"
 
     # Distro packaging is expected to install the ignition binary into the
     # module directory.
@@ -53,6 +57,7 @@ install() {
     install_ignition_unit ignition-mount.service
     install_ignition_unit ignition-files.service
     install_ignition_unit ignition-remount-sysroot.service
+    install_ignition_unit ignition-apply-kargs.service
 
     # needed for openstack config drive support
     inst_rules 60-cdrom_id.rules


### PR DESCRIPTION

As mentioned in https://github.com/coreos/ignition-dracut/issues/81#issuecomment-494888494,
this change adds a service that checks for the presence of `/etc/ostree/kargs.d` and redeploys
then reboots the system if it exists.

Closes: #81