### PR TITLE
dracut/30ignition: support `coreos.no_persist_ip`

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -68,6 +68,8 @@ install() {
 
     # needed for openstack config drive support
     inst_rules 60-cdrom_id.rules
+
+    inst_hook pre-pivot 90 "$moddir/persist-ifcfg.sh"
 }
 
 has_fw_cfg_module() {

--- a/dracut/30ignition/persist-ifcfg.sh
+++ b/dracut/30ignition/persist-ifcfg.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+set -e
+
+cmdline=( $(</proc/cmdline) )
+
+cmdline_arg() {
+    local name="$1" value="$2"
+    for arg in "${cmdline[@]}"; do
+        if [[ "${arg%%=*}" == "${name}" ]]; then
+            value="${arg#*=}"
+        fi
+    done
+    echo "${value}"
+}
+
+cmdline_bool() {
+    local value=$(cmdline_arg "$@")
+    case "$value" in
+        ""|0|no|off) return 1;;
+        *) return 0;;
+    esac
+}
+
+if ! $(cmdline_bool 'coreos.no_persist_ip' 0); then
+    cp /tmp/ifcfg/* /sysroot/etc/sysconfig/network-scripts/
+fi
+

--- a/grub/02_ignition_firstboot
+++ b/grub/02_ignition_firstboot
@@ -20,5 +20,5 @@ if [ -f "(${bootpart})/ignition.firstboot" ]; then
     source "(${bootpart})/ignition.firstboot"
     
     # we support setting variables in the 
-    set ignition_firstboot="ignition.firstboot $ignition_network_kcmdline"
+    set ignition_firstboot="ignition.firstboot $ignition_network_kcmdline $ignition_extra_kcmdline"
 fi


### PR DESCRIPTION
When `coreos.no_persist_ip` is specified on the kcmdline delete
`/etc/sysconfig/network-scripts` that was created by the dracut
`write-ifcfg.sh` script before running Ignition. This allows the use
case of configuring only the initial initramfs networking via ip= to
allow fetching of the Ignition config, and specifying a more complex
real root configuration in the Ignition config.