### PR TITLE
dracut/30ignition: fix typo in module_setup

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -19,7 +19,7 @@ install() {
         chroot \
         groupadd \
         id \
-        lslblk \
+        lsblk \
         mkfs.ext4 \
         mkfs.vfat \
         mkfs.xfs \


### PR DESCRIPTION
Given that this isn't causing errors there's probably something else
pulling it in by the correct name, but we ought to include it here as
well for clarity's sake.