### PR TITLE
[spec2x] persist-ifcfg: Don't persist default ip=dhcp

### DIFF
--- a/dracut/30ignition/persist-ifcfg.sh
+++ b/dracut/30ignition/persist-ifcfg.sh
@@ -24,6 +24,19 @@ cmdline_bool() {
     esac
 }
 
+# We don't persist anything in the default networking case of ip=dhcp;
+# NetworkManager does dhcp by default on connected interfaces by default anyways,
+# and more importantly doing so can clash if a user provides static IP configuration
+# via Ignition, as was supported in OpenShift 4.1.  See
+# https://bugzilla.redhat.com/show_bug.cgi?id=1736875
+ip=$(cmdline_arg ip)
+if [ "${ip}" = "dhcp" ]; then
+    exit 0
+fi
+
+# Unless overridden, propagate the kernel commandline networking into
+# ifcfg files, so that users don't have to write the config in both kernel
+# commandline *and* Ignition.
 if ! $(cmdline_bool 'coreos.no_persist_ip' 0); then
     cp /tmp/ifcfg/* /sysroot/etc/sysconfig/network-scripts/
 fi


### PR DESCRIPTION
We shouldn't persist anything in the default networking case of `ip=dhcp`;
NetworkManager does dhcp by default on connected interfaces by default anyways,
and more importantly doing so can clash if a user provides static IP configuration
via Ignition, as was supported in OpenShift 4.1.  See

https://bugzilla.redhat.com/show_bug.cgi?id=1736875

Closes: https://github.com/coreos/ignition-dracut/issues/96