### PR TITLE
generator: Use ignition.platform.id if available

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -92,13 +92,19 @@ if [ -n "$RANDOMIZE_DISK_GUID" ]; then
     add_requires "disk-uuid@${escaped_guid}.service"
 fi
 
-if [[ $(cmdline_arg coreos.oem.id) == "digitalocean" ]]; then
+oemid=$(cmdline_arg coreos.oem.id)
+# Compatibility Ignition 2 (impl spec 3) as created by coreos-assembler
+if [ -z "${oemid}" ]; then
+    platformid=$(cmdline_arg ignition.platform.id)
+    case "${platformid}" in
+        aws) oemid=ec2;;
+        gcp) oemid=gce;;
+        *) oemid=${platformid}
+    esac
+fi
+
+if [[ "${oemid}" == "digitalocean" ]]; then
     add_requires coreos-digitalocean-network.service
 fi
 
-oem_id=pxe
-if [[ $(systemd-detect-virt || true) =~ ^(kvm|qemu)$ ]]; then
-    oem_id=qemu
-fi
-
-echo "OEM_ID=$(cmdline_arg coreos.oem.id ${oem_id})" > /run/ignition.env
+echo "OEM_ID=${oemid}" > /run/ignition.env


### PR DESCRIPTION
I'm trying to rebase RHCOS on FCOS (though still Ignition spec 2x).
coreos-assembler git master only generates `ignition.platform.id`,
and we also changed some of the IDs.

RHCOS had some code trying to fix this in a separate dracut
module but it wasn't working - I started to debug it but
it really seems *way* cleaner to just patch the spec2x branch
to honor `ignition.platform.id` directly, so that's what this does.

While here, I also intentionally dropped the bits to auto-detect qemu.
That seems hacky; our qemu images should be stamped qemu.

I also dropped the hardcoding of `pxe` as a default; if nothing is
set, then we don't try to guess.