### PR TITLE
Makefile: New file implementing `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all
+all:
+	@echo "(No build step)"
+
+.PHONY: install
+install: all
+	for x in dracut/*; do \
+	  bn=$$(basename $$x); \
+	  install -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$${bn} $$x/*; \
+	done
+	install -D -t $(DESTDIR)/usr/lib/systemd/system systemd/*
+	install -D -t $(DESTDIR)/etc/grub.d grub/*


### PR DESCRIPTION
See https://github.com/cgwalters/build-api

With this for example, we can just have the Fedora spec file do
`make install DESTDIR=$RPM_BUILD_ROOT` just like everything else;
helping to ensure that as much logic as possible remains upstream.

Mainly I want this for hacking so I can just
`make install DESTDIR=/srv/walters/fcos/overrides/rootfs`
without building an RPM or copying files manually.