### PR TITLE
Add RemainAfterExit=yes to systemd units of Type=oneshot

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -27,5 +27,6 @@ After=systemd-udevd.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
 ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=disks

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -12,5 +12,6 @@ Before=initrd-parse-etc.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
 ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=files --log-to-stdout


### PR DESCRIPTION
Omitting this can cause the unit to be executed multiple
times if it's a dependency of another unit (as these are).

See https://github.com/ostreedev/ostree/pull/1697
and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=750683