### PR TITLE
dracut: Add an ignition-fetch.service

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -2,6 +2,7 @@
 Description=Ignition (disks)
 DefaultDependencies=false
 Before=ignition-complete.target
+After=ignition-fetch.service
 
 # This stage runs between `basic.target` and `initrd-root-fs.target`,
 # see https://www.freedesktop.org/software/systemd/man/bootup.html
@@ -9,17 +10,8 @@ Before=ignition-complete.target
 # Note that CL runs this before `local-fs-pre.target` to allow for configs that
 # completely wipe the rootfs. Though we're not there yet. But we still run
 # before `sysroot.mount` on principle.
-After=basic.target
 Before=initrd-root-fs.target
 Before=sysroot.mount
-
-# Run after ignition-setup has run because ignition-setup
-# may copy in new/different ignition configs for us to consume.
-After=ignition-setup-base.service
-After=ignition-setup-user.service
-
-# Network may be used to fetch userdata content.
-After=network.target
 
 # This stage requires udevd to detect disk partitioning changes.
 Requires=systemd-udevd.service

--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Ignition (fetch)
+DefaultDependencies=false
+Before=ignition-complete.target
+After=basic.target
+
+# Run after ignition-setup has run because ignition-setup
+# may copy in new/different ignition configs for us to consume.
+After=ignition-setup-base.service
+After=ignition-setup-user.service
+
+# Network may be used to fetch userdata content.
+After=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/run/ignition.env
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -60,6 +60,7 @@ install() {
 
     install_ignition_unit ignition-setup-base.service
     install_ignition_unit ignition-setup-user.service
+    install_ignition_unit ignition-fetch.service
     install_ignition_unit ignition-disks.service
     install_ignition_unit ignition-mount.service
     install_ignition_unit ignition-files.service


### PR DESCRIPTION
This invokes the new `fetch` stage which does just that - fetch
the Ignition config into `/run/ignition.json` and nothing else.

Prep for adding support for redeploying the rootfs, which is
an expensive process, so we only want to do it if the fetched
Ignition config is replacing the `rootfs`.