### PR TITLE
30ignition: Failure handling improvements

### DIFF
--- a/dracut/30ignition/coreos-gpt-setup@.service
+++ b/dracut/30ignition/coreos-gpt-setup@.service
@@ -2,6 +2,7 @@
 Description=Generate new UUID for disk GPT %I
 DefaultDependencies=no
 Before=local-fs-pre.target systemd-fsck-root.service
+Before=ignition-diskful.target
 Wants=systemd-udevd.service
 After=systemd-udevd.service
 Requires=%i.device

--- a/dracut/30ignition/ignition-complete.target
+++ b/dracut/30ignition/ignition-complete.target
@@ -7,9 +7,10 @@
 Description=Ignition Complete
 Before=initrd.target
 
-# Make sure if any ExecStart= fail, the boot fails. This normally would
-# already be guaranteed by `initrd.target` failing, but that doesn't seem to be
-# enough: https://bugzilla.redhat.com/show_bug.cgi?id=1696796
+# initrd.target has OnFailureJobMode=replace-irreversibly, which seems to
+# cause unit restart loops in the initramfs if one of our units fails.  Thus
+# we intercept Ignition unit failures here and isolate to emergency.target.
+# https://github.com/coreos/ignition-dracut/issues/115
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 

--- a/dracut/30ignition/ignition-diskful.target
+++ b/dracut/30ignition/ignition-diskful.target
@@ -3,7 +3,7 @@
 # Like ignition-complete.target, it only runs on first boot.
 [Unit]
 Description=Ignition Boot Disk Setup
-Before=initrd.target
+Before=ignition-complete.target
 
 # Make sure if any ExecStart= fail, the boot fails. This normally would
 # already be guaranteed by `initrd.target` failing, but that doesn't seem to be

--- a/dracut/30ignition/ignition-diskful.target
+++ b/dracut/30ignition/ignition-diskful.target
@@ -5,12 +5,6 @@
 Description=Ignition Boot Disk Setup
 Before=ignition-complete.target
 
-# Make sure if any ExecStart= fail, the boot fails. This normally would
-# already be guaranteed by `initrd.target` failing, but that doesn't seem to be
-# enough: https://bugzilla.redhat.com/show_bug.cgi?id=1696796
-OnFailure=emergency.target
-OnFailureJobMode=isolate
-
 # Make sure we stop all the units before switching root
 Conflicts=initrd-switch-root.target umount.target
 Conflicts=dracut-emergency.service emergency.service emergency.target

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -4,7 +4,7 @@ Description=Remount /sysroot read-write for Ignition
 # commandline and thus mount the root filesystem ro by default. In
 # this case, remount /sysroot to rw (issue #37)
 DefaultDependencies=no
-Before=ignition-complete.target
+Before=ignition-diskful.target
 
 After=sysroot.mount
 ConditionPathIsReadWrite=!/sysroot


### PR DESCRIPTION
Failed units in `ignition-diskful.target` weren't correctly causing boot failures, since several units weren't properly sequenced `Before` the respective target that was supposed to handle their failure.

I also dug a bit into the need for `ignition-complete.target` to carry its own `OnFailure` declaration.  The test case in [@jlebon's bug](https://bugzilla.redhat.com/show_bug.cgi?id=1696796) no longer works on F30/F31.  Overriding `initrd.target` to `OnFailureJobMode=isolate`, as @jlebon suggested, does avoid the problem.  Since the workaround in `ignition-complete.target` is localized and I believe it to be reliable, I've updated the comment there and am inclined to leave it alone for now.

Part of https://github.com/coreos/fedora-coreos-config/pull/177.