### PR TITLE
dracut: Remove stray After=basic.target for ignition-fetch.service

### DIFF
--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -2,7 +2,6 @@
 Description=Ignition (fetch)
 DefaultDependencies=false
 Before=ignition-complete.target
-After=basic.target
 
 # Run after ignition-setup has run because ignition-setup
 # may copy in new/different ignition configs for us to consume.


### PR DESCRIPTION
I had this fix in my WIP ignition-ostree-rootfs stack, and apparently
missed putting it in the split-out change.

This service runs really really early on, it can't be `After=basic.target`.