### PR TITLE
firstboot-complete: tell zipl to run

### DIFF
--- a/systemd/ignition-firstboot-complete.service
+++ b/systemd/ignition-firstboot-complete.service
@@ -18,7 +18,13 @@ RemainAfterExit=yes
 # detected this file. Fail if we are unable to remove it, rather than risking
 # rerunning Ignition at next boot.
 MountFlags=slave
-ExecStart=/bin/sh -c 'mount -o remount,rw /boot && rm /boot/ignition.firstboot'
+# It is better to have a separate script to do this but it might be polluting
+# the target system with some script in i.e. /usr/sbin/firstboot-complete
+# The retval code is still respected with having this if-else block.
+ExecStart=/bin/sh -c \
+	'mount -o remount,rw /boot && \
+	if [[ $(uname -m) = s390x ]]; then zipl; fi && \
+	rm /boot/ignition.firstboot'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
zipl records need to be updated, because ignition.firstboot is burned
into target disk during coreos-installer

As a short-term solution for:
https://github.com/coreos/ignition-dracut/issues/84

Depends on:
https://github.com/ibm-s390-tools/s390-tools/pull/71
https://github.com/ibm-s390-tools/s390-tools/pull/74

Related:
https://github.com/coreos/coreos-installer/pull/61
https://github.com/coreos/coreos-assembler/pull/780