### PR TITLE
30ignition: Minor cleanup to install script

### DIFF
--- a/dracut/30ignition/ignition-setup.sh
+++ b/dracut/30ignition/ignition-setup.sh
@@ -11,12 +11,12 @@ copy_file_if_exists() {
     fi
 }
 
-destination=/usr/lib/ignition/
+destination=/usr/lib/ignition
 mkdir -p $destination
 
 # We will support grabbing a platform specific base.ign config
 # from the initrd at /usr/lib/ignition/platform/${OEM_ID}/base.ign
-copy_file_if_exists "/usr/lib/ignition/platform/${OEM_ID}/base.ign" "${destination}/base.ign"
+copy_file_if_exists "${destination}/platform/${OEM_ID}/base.ign" "${destination}/base.ign"
 
 # We will support a user embedded config in the boot partition
 # under $bootmnt/ignition/config.ign. Note that we mount /boot


### PR DESCRIPTION
I was just looking at the script and seen $destination could be used
 in another place instead of duplicating '/usr/lib/ignition'