### PR TITLE
[spec2x]  teardown: skip bonding_masters

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 if ! [ -z "$(ls /sys/class/net)" ]; then
     for f in /sys/class/net/*; do
         interface=$(basename "$f")
+        # Skip bond interface brought up by initramfs
+        if [ "$interface" == "bonding_masters" ]; then continue; fi
         ip link set $interface down
         ip addr flush dev $interface
         rm -f -- /tmp/net.$interface.did-setup


### PR DESCRIPTION
`bonding_masters` interface is used by initramfs to start bonding connection and it cannot be brought down cleanly.

This PR would skip this interface during initramfs networking teardown.

Verified that it works with:

* [x] IP via DHCP
* [x] Static IP via kernel arguments
* [x] Static IP with bonded interfaces 

Fixes bugzilla.redhat.com/show_bug.cgi?id=1758091
