### PR TITLE
[spec2x] ignition-firstboot-complete.service: Run as part of basic.target

### DIFF
--- a/systemd/ignition-firstboot-complete.service
+++ b/systemd/ignition-firstboot-complete.service
@@ -20,4 +20,5 @@ MountFlags=slave
 ExecStart=/bin/sh -c 'mount -o remount,rw /boot && rm /boot/ignition.firstboot'
 
 [Install]
-WantedBy=multi-user.target
+# Part of basic.target so this happens early on in firstboot
+WantedBy=basic.target


### PR DESCRIPTION
See: https://github.com/openshift/installer/pull/2554

Basically the OpenShift installer on vSphere injects a service which reboots
the first time, but I believe this could easily race with `ignition-firstboot-complete`.

Let's mark the boot complete much earlier.

(cherry picked from commit 598bbdded7c683d22d572bfbf6d76139a86ebd19)