### PR TITLE
Makefile: Fix spec2x backport mistake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all:
 .PHONY: install
 install: all
 	for x in dracut/*; do \
-	  if ! [ -d "${x}" ]; then continue; fi; \
+	  if ! [ -d "$${x}" ]; then continue; fi; \
 	  bn=$$(basename $$x); \
 	  install -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$${bn} $$x/*; \
 	done


### PR DESCRIPTION
I had to add this line to skip the `README.txt` that only exists in the `spec2x` branch and...

It silently appeared to work (just didn't install the files),
but I had them already there from a previous run from the
master branch...this resulted in a lost 10 minutes of tracing
down exactly why my changes weren't appearing :cry: