### PR TITLE
persist-ifcfg: Don't overwrite extant files

### DIFF
--- a/dracut/30ignition/persist-ifcfg.sh
+++ b/dracut/30ignition/persist-ifcfg.sh
@@ -37,7 +37,7 @@ persist_ifcfg() {
     # ifcfg files, so that users don't have to write the config in both kernel
     # commandline *and* Ignition.
     if ! $(cmdline_bool 'coreos.no_persist_ip' 0); then
-        cp /tmp/ifcfg/* /sysroot/etc/sysconfig/network-scripts/
+        cp -n /tmp/ifcfg/* /sysroot/etc/sysconfig/network-scripts/
     fi
 }
 


### PR DESCRIPTION
This currently runs *after* Ignition, and we shouldn't
overwrite any config files people created that way.

Now in practice, automatic persistence and manual configuration
are probably only sanely mutually exlusive, but let's do the
obviously right thing if someone decides to mix them.