### PR TITLE
30ignition: backport of the fetch stage

### DIFF
--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Ignition (fetch)
+DefaultDependencies=false
+Before=ignition-complete.target
+After=basic.target
+
+# Run after ignition-setup has run because ignition-setup
+# may copy in new/different ignition configs for us to consume.
+After=ignition-setup.service
+Before=ignition-disks.service
+Before=ignition-files.service
+
+# Network may be used to fetch userdata content.
+After=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/run/ignition.env
+ExecStart=/usr/bin/ignition --root=/sysroot --oem=${OEM_ID} --stage=fetch

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -36,6 +36,7 @@ add_requires() {
 # starts the unit's dependencies. We want to start networkd only on first
 # boot.
 if $(cmdline_bool 'ignition.firstboot' 0); then
+    add_requires ignition-fetch.service
     add_requires ignition-disks.service
     add_requires ignition-files.service
     add_requires ignition-ask-var-mount.service

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -45,6 +45,9 @@ install() {
     inst_simple "$moddir/ignition-disks.service" \
         "$systemdsystemunitdir/ignition-disks.service"
 
+    inst_simple "$moddir/ignition-fetch.service" \
+        "$systemdsystemunitdir/ignition-fetch.service"
+
     inst_simple "$moddir/ignition-files.service" \
         "$systemdsystemunitdir/ignition-files.service"
 


### PR DESCRIPTION
This is a backport of the fetch stage but modified for `spec2x`. RHCOS needs the fetch stage to enable encryption. 