### PR TITLE
persist-ifcfg: Ensure files we write have SELinux labels

### DIFF
--- a/dracut/30ignition/persist-ifcfg.sh
+++ b/dracut/30ignition/persist-ifcfg.sh
@@ -38,6 +38,7 @@ persist_ifcfg() {
     # commandline *and* Ignition.
     if ! $(cmdline_bool 'coreos.no_persist_ip' 0); then
         cp -n /tmp/ifcfg/* /sysroot/etc/sysconfig/network-scripts/
+        echo -ne '/etc/sysconfig/network-scripts/\0' >> /sysroot/etc/selinux/ignition.relabel
     fi
 }
 


### PR DESCRIPTION
Do it the same way Ignition works on the spec2x branch.

This came up as the NM state operator being unable to modify the files.