### PR TITLE
Add `ignition-subsequent.target` for non-Ignition boots

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -53,6 +53,12 @@ Requires=dev-disk-by\x2dlabel-boot.device
 After=dev-disk-by\x2dlabel-boot.device
 EOF
     fi
+else
+    # If we're doing a non-Ignition (subsequent) boot, then
+    # queue a different target.  This is necessary so that units
+    # like `ignition-ostree-mount-sysroot.service`
+    # can cleanly distinguish between the two.
+    add_requires ignition-subsequent.target initrd.target
 fi
 
 echo "PLATFORM_ID=$(cmdline_arg ignition.platform.id)" > /run/ignition.env

--- a/dracut/30ignition/ignition-subsequent.target
+++ b/dracut/30ignition/ignition-subsequent.target
@@ -1,0 +1,14 @@
+# This target is queued to run when Ignition will *not* run.
+# It's intended right now for mounting sysroot, which happens in a quite
+# different order on the Ignition boot versus "subsequent" boots.
+[Unit]
+Description=Subsequent (Not Ignition) boot complete
+Before=initrd.target
+
+# See comments in ignition-complete.target
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+# Make sure we stop all the units before switching root
+Conflicts=initrd-switch-root.target umount.target
+Conflicts=dracut-emergency.service emergency.service emergency.target

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -54,6 +54,8 @@ install() {
 
     inst_simple "$moddir/ignition-complete.target" \
         "$systemdsystemunitdir/ignition-complete.target"
+    inst_simple "$moddir/ignition-subsequent.target" \
+        "$systemdsystemunitdir/ignition-subsequent.target"
 
     inst_simple "$moddir/ignition-diskful.target" \
         "$systemdsystemunitdir/ignition-diskful.target"


### PR DESCRIPTION
This is needed for Fedora CoreOS work on reprovisioning
the rootfs.  We tried to split out a systemd unit to handle
mounting the root in this commit:
https://github.com/coreos/fedora-coreos-config/pull/187/commits/a6fe3749262cad8d35d73efb657dea1c9add7dd4
with `ignition-ostree-mount-sysroot.service` but the problem
is that needs to have different dependencies/ordering if we're
doing the "Ignition boot" versus a "subsequent" boot.

Add a new target that's queued up if we detect we're doing
a "subsequent" boot.