### PR TITLE
30ignition/ignition-setup-user: mount /boot partition ro

### DIFF
--- a/dracut/30ignition/ignition-setup-user.sh
+++ b/dracut/30ignition/ignition-setup-user.sh
@@ -25,6 +25,8 @@ else
     # with MountFlags=slave so it is unmounted for us.
     bootmnt=/mnt/boot_partition
     mkdir -p $bootmnt
-    mount /dev/disk/by-label/boot $bootmnt
+    # mount as read-only since we don't strictly need write access and we may be
+    # running alongside other code that also has it mounted ro
+    mount -o ro /dev/disk/by-label/boot $bootmnt
     copy_file_if_exists "${bootmnt}/ignition/config.ign" "${destination}/user.ign"
 fi


### PR DESCRIPTION
We don't actually need write access to `/boot` here to pull out any
baked Ignition config. Just mount it read-only.

This also helps in the case where any other service is concurrently also
mounting `/boot`: trying to mount a device as read-write that's already
mounted read-only elsewhere will fail. I hit this when playing with FIPS
mode, which does this:

https://github.com/dracutdevs/dracut/blob/718aefda1374c7b6c3790b08cae27fd6bde505af/modules.d/01fips/fips.sh#L49