### PR TITLE
fetch: Inject headers from /usr/lib/os-release

### DIFF
--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -16,4 +16,6 @@ After=network.target
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch
+EnvironmentFile=/usr/lib/os-release
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch \
+          --fetch-header ignition-os-id=${ID} --fetch-header ignition-os-version-id=${VERSION_ID}


### PR DESCRIPTION
Depends: https://github.com/coreos/ignition/pull/889

So that the openshift/machine-config-operator server can dispatch
on them to aid with Ignition spec 3 transitions.