### PR TITLE
Enforce that Ignition run once even if interrupted

### DIFF
--- a/dracut/30ignition/ignition-finished.service
+++ b/dracut/30ignition/ignition-finished.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ignition (log completion)
+DefaultDependencies=false
+Before=ignition-complete.target
+After=basic.target
+
+After=ignition-files.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+MountFlags=slave
+TemporaryFileSystem=/run/boot
+# Flag completion of Ignition, so that we can immediately error out if we detect we started
+ExecStart=/bin/sh -c 'mount /dev/disk/by-label/boot /run/boot && echo completed > /run/boot/ignition.state'

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -52,6 +52,11 @@ if $(cmdline_bool 'ignition.firstboot' 0); then
 Requires=dev-disk-by\x2dlabel-boot.device
 After=dev-disk-by\x2dlabel-boot.device
 EOF
+
+        # And these units write to /boot too
+        for unit in prelaunch started finished; do
+            add_requires ignition-${unit}.service ignition-complete.target
+        done
     fi
 else
     # If we're doing a non-Ignition (subsequent) boot, then

--- a/dracut/30ignition/ignition-prelaunch.service
+++ b/dracut/30ignition/ignition-prelaunch.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Ignition (validate first run)
+DefaultDependencies=false
+Before=ignition-complete.target
+After=basic.target
+
+Before=ignition-fetch.service
+
+Requires=dev-disk-by\x2dlabel-boot.device
+After=dev-disk-by\x2dlabel-boot.device
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+MountFlags=slave
+TemporaryFileSystem=/run/boot
+# Flag completion of Ignition, so that we can immediately error out if we detect we started
+ExecStart=/bin/sh -c 'mount -o ro /dev/disk/by-label/boot /run/boot && if [ -f /run/boot/ignition.state ]; then echo -n "Detected previous run of Ignition:" $(cat /run/boot/ignition.state); exit 1; fi'
+

--- a/dracut/30ignition/ignition-started.service
+++ b/dracut/30ignition/ignition-started.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Ignition (log initiation)
+DefaultDependencies=false
+Before=ignition-complete.target
+After=basic.target
+
+# Run after ignition-setup has run because ignition-setup
+# may copy in new/different ignition configs for us to consume.
+After=ignition-fetch.service
+Before=ignition-disks.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+MountFlags=slave
+TemporaryFileSystem=/run/boot
+# Flag initiation of Ignition, so that we can immediately error out if we detect we started
+ExecStart=/bin/sh -c 'mount /dev/disk/by-label/boot /run/boot && echo started > /run/boot/ignition.state'

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -59,7 +59,8 @@ install() {
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
 
-    for x in "complete" "subsequent" "diskful" "diskful-subsequent"; do
+    for x in "complete" "subsequent" "diskful" "diskful-subsequent"
+             "prelaunch" "started" "finished"; do
         inst_simple "$moddir/ignition-$x.target" \
             "$systemdsystemunitdir/ignition-$x.target"
     done


### PR DESCRIPTION
I have seen in practice us trying to run Ignition multiple times
if the system is forcibly rebooted before we run the firstboot
complete service, which actually today runs in the real rootfs.

Forcibly prevent this by adding a few tiny new shell scripts
which write a state file to `/boot/ignition.state`.  The first
to run is `ignition-prelaunch.service` which runs even before
`fetch` and bombs out directly if we detect the stamp file
exists.

Next, we have a service which writes the stamp file after `fetch`
and before `disks`.  Finally, another service updates the stamp
file just to signal `complete`.

Note none of these services run on live systems, as there's
no `/boot` there, and Ignition runs every boot anyways.