### PR TITLE
Add ConditionPathExists=/etc/initrd-release to targets

### DIFF
--- a/dracut/30ignition/ignition-complete.target
+++ b/dracut/30ignition/ignition-complete.target
@@ -6,6 +6,7 @@
 [Unit]
 Description=Ignition Complete
 Before=initrd.target
+ConditionPathExists=/etc/initrd-release
 
 # initrd.target has OnFailureJobMode=replace-irreversibly, which seems to
 # cause unit restart loops in the initramfs if one of our units fails.  Thus

--- a/dracut/30ignition/ignition-subsequent.target
+++ b/dracut/30ignition/ignition-subsequent.target
@@ -4,6 +4,7 @@
 [Unit]
 Description=Subsequent (Not Ignition) boot complete
 Before=initrd.target
+ConditionPathExists=/etc/initrd-release
 
 # See comments in ignition-complete.target
 OnFailure=emergency.target


### PR DESCRIPTION
I noticed that several of our units actually run twice, including
`ignition-files.service` (!) and `ignition-ostree-mount-firstboot-sysroot.service`.

Looking deeper into this, I discovered a bit of the initrd that
I didn't even know existed, which is `initrd-parse-etc.service`
that actually runs `ExecStart=-/usr/bin/systemctl --no-block start initrd-fs.target`
*post* switch root, after services that are part of that target
have already run (and then been shut down).

This adds a big wrinkle to my understanding of system bootup.

Then I noticed that `initrd-fs.target` has:
`ConditionPathExists=/etc/initrd-release`
which will be false post-switchroot.

The semantics here are...strange.  It seems like the goal is to ensure
that the rootfs is definitely still mounted, perhaps in
very complex rootfs scenarios?  In our case it will still be
mounted, we definitely don't want to rerun any of our Ignition
units.

Adding the same condition to our targets ensures that they
aren't re-run post switchroot.