### PR TITLE
generator: Bind main Ignition units to ignition-complete.target

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -39,9 +39,9 @@ add_requires() {
 if $(cmdline_bool 'ignition.firstboot' 0); then
     add_requires ignition-complete.target initrd.target
     for svc in fetch disks files mount ask-var-mount; do
-        add_requires ignition-${svc}.service initrd.target
+        add_requires ignition-${svc}.service ignition-complete.target
     done
-    add_requires coreos-teardown-initramfs-network.service initrd.target
+    add_requires coreos-teardown-initramfs-network.service ignition-complete.target
     #if [[ $(cmdline_arg coreos.oem.id) == "packet" ]]; then
     #    add_requires coreos-static-network.service
     #fi


### PR DESCRIPTION
Instead of `initrd.target`.  This matches with what happens on
master, and will help ensure that the units aren't rerun as part of
`initrd-parse-etc.service` in concert with adding
`ConditionPathExists=/etc/initrd-release` to the targets.