### PR TITLE
units: add ConditionPathExists=/etc/initrd-release everywhere

### DIFF
--- a/dracut/30ignition/coreos-gpt-setup@.service
+++ b/dracut/30ignition/coreos-gpt-setup@.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Generate new UUID for disk GPT %I
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 DefaultDependencies=no
 Before=local-fs-pre.target systemd-fsck-root.service
 Before=ignition-diskful.target

--- a/dracut/30ignition/ignition-complete.target
+++ b/dracut/30ignition/ignition-complete.target
@@ -5,8 +5,9 @@
 # initrd.
 [Unit]
 Description=Ignition Complete
-Before=initrd.target
+Documentation=https://github.com/coreos/ignition
 ConditionPathExists=/etc/initrd-release
+Before=initrd.target
 
 # initrd.target has OnFailureJobMode=replace-irreversibly, which seems to
 # cause unit restart loops in the initramfs if one of our units fails.  Thus

--- a/dracut/30ignition/ignition-diskful.target
+++ b/dracut/30ignition/ignition-diskful.target
@@ -3,6 +3,8 @@
 # Like ignition-complete.target, it only runs on first boot.
 [Unit]
 Description=Ignition Boot Disk Setup
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 Before=ignition-complete.target
 
 # Make sure we stop all the units before switching root

--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ignition (disks)
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 After=ignition-fetch.service

--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ignition (fetch)
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 After=basic.target

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ignition (files)
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 

--- a/dracut/30ignition/ignition-mount.service
+++ b/dracut/30ignition/ignition-mount.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ignition (mount)
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Remount /sysroot read-write for Ignition
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 # Some Linux Distributions don't pass a rw option on the kernel
 # commandline and thus mount the root filesystem ro by default. In
 # this case, remount /sysroot to rw (issue #37)

--- a/dracut/30ignition/ignition-setup-base.service
+++ b/dracut/30ignition/ignition-setup-base.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ignition (setup base config)
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 

--- a/dracut/30ignition/ignition-setup-user.service
+++ b/dracut/30ignition/ignition-setup-user.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ignition (setup user config)
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 

--- a/dracut/30ignition/ignition-subsequent.target
+++ b/dracut/30ignition/ignition-subsequent.target
@@ -3,8 +3,9 @@
 # different order on the Ignition boot versus "subsequent" boots.
 [Unit]
 Description=Subsequent (Not Ignition) boot complete
-Before=initrd.target
+Documentation=https://github.com/coreos/ignition
 ConditionPathExists=/etc/initrd-release
+Before=initrd.target
 
 # See comments in ignition-complete.target
 OnFailure=emergency.target


### PR DESCRIPTION
This is standard practice for units that are only meant to run in the
initrd. It matches what e.g. `systemd` does for its initrd units. See
also: https://github.com/coreos/ignition-dracut/pull/140.

I also snuck in `Documentation=` lines in there.