### PR TITLE
Adapt to move to ip=dhcp,dhcp6

### DIFF
--- a/dracut/30ignition/persist-ifcfg.sh
+++ b/dracut/30ignition/persist-ifcfg.sh
@@ -29,7 +29,7 @@ persist_ifcfg() {
     # via Ignition, as was supported in OpenShift 4.1.  See
     # https://bugzilla.redhat.com/show_bug.cgi?id=1736875
     ip=$(cmdline_arg ip)
-    if [ "${ip}" = "dhcp" ]; then
+    if [ "${ip}" = "dhcp" ] || [ "${ip}" = "dhcp,dhcp6" ]; then
         return 0
     fi
 

--- a/grub/02_ignition_firstboot
+++ b/grub/02_ignition_firstboot
@@ -10,7 +10,7 @@ search --set=bootpart --label boot
 set ignition_firstboot=""
 if [ -f "(${bootpart})/ignition.firstboot" ]; then
     # default to dhcp networking parameters to be used with ignition 
-    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp'
+    set ignition_network_kcmdline='rd.neednet=1 ip=dhcp,dhcp6'
 
     # source in the `ignition.firstboot` file which could override the
     # above $ignition_network_kcmdline with static networking config.


### PR DESCRIPTION
coreos-assembler moved now to `ip=dhcp,dhcp6`, so we need to adapt the
ifcfg persist logic here:

https://github.com/coreos/coreos-assembler/pull/1067

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1793591