### PR TITLE
Makefile: Remove grub/ install bits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,3 @@ install: all
 	  install -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$${bn} $$x/*; \
 	done
 	install -D -t $(DESTDIR)/usr/lib/systemd/system systemd/*
-	install -D -t $(DESTDIR)/etc/grub.d grub/*


### PR DESCRIPTION
`make install` was failing now that the grub bits are gone.