### PR TITLE
Add ignition-diskful-subsequent.target

### DIFF
--- a/dracut/30ignition/ignition-diskful-subsequent.target
+++ b/dracut/30ignition/ignition-diskful-subsequent.target
@@ -1,0 +1,12 @@
+# This target is a combination of ignition-subsequent.target and
+# ignition-diskful.target - units here should only run when we have a
+# boot disk and *aren't* doing the first boot.
+[Unit]
+Description=Ignition Subsequent Boot Disk Setup
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
+Before=ignition-subsequent.target
+
+# Make sure we stop all the units before switching root
+Conflicts=initrd-switch-root.target umount.target
+Conflicts=dracut-emergency.service emergency.service emergency.target

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -59,6 +59,9 @@ else
     # like `ignition-ostree-mount-sysroot.service`
     # can cleanly distinguish between the two.
     add_requires ignition-subsequent.target initrd.target
+    if ! command -v is-live-image >/dev/null || ! is-live-image; then
+        add_requires ignition-diskful-subsequent.target ignition-subsequent.target
+    fi
 fi
 
 echo "PLATFORM_ID=$(cmdline_arg ignition.platform.id)" > /run/ignition.env

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -59,13 +59,10 @@ install() {
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"
 
-    inst_simple "$moddir/ignition-complete.target" \
-        "$systemdsystemunitdir/ignition-complete.target"
-    inst_simple "$moddir/ignition-subsequent.target" \
-        "$systemdsystemunitdir/ignition-subsequent.target"
-
-    inst_simple "$moddir/ignition-diskful.target" \
-        "$systemdsystemunitdir/ignition-diskful.target"
+    for x in "complete" "subsequent" "diskful" "diskful-subsequent"; do
+        inst_simple "$moddir/ignition-$x.target" \
+            "$systemdsystemunitdir/ignition-$x.target"
+    done
 
     install_ignition_unit ignition-setup-base.service
     install_ignition_unit ignition-setup-user.service


### PR DESCRIPTION
This target is a combination of `ignition-subsequent.target` and
`ignition-diskful.target` - units here should only run when we have a
boot disk and *aren't* doing the first boot.

This came out of discussion in
https://github.com/coreos/fedora-coreos-config/pull/271

Will be used by FCOS.

Suggested-by: @jlebon