### PR TITLE
Hook up to CoreOS CI

### DIFF
--- a/.cci.jenkinsfile
+++ b/.cci.jenkinsfile
@@ -1,0 +1,6 @@
+// Documentation: https://github.com/coreos/coreos-ci/blob/master/README-upstream-ci.md
+
+cosaPod {
+    checkout scm
+    fcosBuild(make: true)
+}


### PR DESCRIPTION
This is the first repo that we hook up to the new CoreOS CI interface.
And it's sorely needed too, since patches here can easily result in
broken boots.