### PR TITLE
add coreos-teardown-initramfs-network.service

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs-network.service
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.service
@@ -1,0 +1,21 @@
+# Clean up the initramfs networking on first boot
+# so the real network is being brought up
+# https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
+
+[Unit]
+Description=Tear down initramfs networking
+DefaultDependencies=false
+After=ignition-files.service
+
+# Make sure ExecStop= runs before we switch root
+Conflicts=initrd-switch-root.target umount.target
+Before=initrd-switch-root.target
+
+# Make sure if ExecStart= fails, the boot fails
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStop=/usr/sbin/coreos-teardown-initramfs-network

--- a/dracut/30ignition/coreos-teardown-initramfs-network.service
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.service
@@ -6,6 +6,7 @@
 Description=Tear down initramfs networking
 DefaultDependencies=false
 After=ignition-files.service
+Before=ignition-complete.target
 
 # Make sure ExecStop= runs before we switch root
 Conflicts=initrd-switch-root.target umount.target

--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -34,7 +34,6 @@ down_interface() {
     echo "info: taking down network device: $1"
     ip link set $1 down
     ip addr flush dev $1
-    rm -f -- /tmp/net.$1.did-setup
 }
 
 down_bonds() {
@@ -72,6 +71,10 @@ main() {
     down_interfaces
     # Propagate initramfs networking if needed
     propagate_initramfs_networking
+    # Now that the configuration has been propagated (or not)
+    # clean it up so that no information from outside of the
+    # real root is passed on to NetworkManager in the real root
+    rm -rf /run/NetworkManager/
 }
 
 main

--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+set -euo pipefail
+
+down_interface() {
+    ip link set $1 down
+    ip addr flush dev $1
+    rm -f -- /tmp/net.$1.did-setup
+}
+
+# We want to take down the bonded interfaces first
+if [ -f "/sys/class/net/bonding_masters" ]; then
+    bonds="$(cat /sys/class/net/bonding_masters)"
+    for b in ${bonds[@]}; do
+        down_interface ${b}
+        echo -"${b}" > /sys/class/net/bonding_masters
+     done
+fi
+
+# Clean up the interfaces set up in the initramfs
+# This mimics the behaviour of dracut's ifdown() in net-lib.sh
+if ! [ -z "$(ls /sys/class/net)" ]; then
+    for f in /sys/class/net/*; do
+        interface=$(basename "$f")
+        # The `bonding_masters` entry is not a true interface and thus
+        # cannot be taken down.  If they existed, the bonded interfaces
+        # were taken down earlier in this script.
+        if [ "$interface" == "bonding_masters" ]; then continue; fi
+        down_interface $interface
+    done
+fi

--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -36,6 +36,12 @@ down_interface() {
     ip addr flush dev $1
 }
 
+down_teams() {
+    # We think since teaming is mostly achieved in userspace (with a
+    # daemon) we don't think there is anything to do here because the
+    # daemon will get taken down before the switch to the real root.
+}
+
 down_bonds() {
     if [ -f "/sys/class/net/bonding_masters" ]; then
         bonds="$(cat /sys/class/net/bonding_masters)"
@@ -65,9 +71,10 @@ down_interfaces() {
 }
 
 main() {
-    # We want to take down the bonded interfaces first
+    # We want to take down the bonds/teams first and then clean
+    # up interfaces set up in the ininitramfs
     down_bonds
-    # Clean up the interfaces set up in the initramfs
+    down_teams
     down_interfaces
     # Propagate initramfs networking if needed
     propagate_initramfs_networking

--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -76,8 +76,15 @@ main() {
     down_bonds
     down_teams
     down_interfaces
+
+    # Clean up all routing
+    echo "info: flushing all routing"
+    ip route flush table main
+    ip route flush cache
+
     # Propagate initramfs networking if needed
     propagate_initramfs_networking
+
     # Now that the configuration has been propagated (or not)
     # clean it up so that no information from outside of the
     # real root is passed on to NetworkManager in the real root

--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -5,29 +5,45 @@
 set -euo pipefail
 
 down_interface() {
+    echo "info: taking down network device: $1"
     ip link set $1 down
     ip addr flush dev $1
     rm -f -- /tmp/net.$1.did-setup
 }
 
-# We want to take down the bonded interfaces first
-if [ -f "/sys/class/net/bonding_masters" ]; then
-    bonds="$(cat /sys/class/net/bonding_masters)"
-    for b in ${bonds[@]}; do
-        down_interface ${b}
-        echo -"${b}" > /sys/class/net/bonding_masters
-     done
-fi
+down_bonds() {
+    if [ -f "/sys/class/net/bonding_masters" ]; then
+        bonds="$(cat /sys/class/net/bonding_masters)"
+        for b in ${bonds[@]}; do
+            down_interface ${b}
+            echo -"${b}" > /sys/class/net/bonding_masters
+         done
+    fi
+}
 
-# Clean up the interfaces set up in the initramfs
 # This mimics the behaviour of dracut's ifdown() in net-lib.sh
-if ! [ -z "$(ls /sys/class/net)" ]; then
-    for f in /sys/class/net/*; do
-        interface=$(basename "$f")
-        # The `bonding_masters` entry is not a true interface and thus
-        # cannot be taken down.  If they existed, the bonded interfaces
-        # were taken down earlier in this script.
-        if [ "$interface" == "bonding_masters" ]; then continue; fi
-        down_interface $interface
-    done
-fi
+# Note that in the futre we would like to possibly use `nmcli` networking off`
+# for this. See the following two comments for details:
+# https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
+# https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599746049
+down_interfaces() {
+    if ! [ -z "$(ls /sys/class/net)" ]; then
+        for f in /sys/class/net/*; do
+            interface=$(basename "$f")
+            # The `bonding_masters` entry is not a true interface and thus
+            # cannot be taken down.  If they existed, the bonded interfaces
+            # were taken down earlier in this script.
+            if [ "$interface" == "bonding_masters" ]; then continue; fi
+            down_interface $interface
+        done
+    fi
+}
+
+main() {
+    # We want to take down the bonded interfaces first
+    down_bonds
+    # Clean up the interfaces set up in the initramfs
+    down_interfaces
+}
+
+main

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -39,6 +39,10 @@ add_requires() {
 if $(cmdline_bool 'ignition.firstboot' 0); then
     add_requires ignition-complete.target initrd.target
 
+    # For consistency tear down the network between the initramfs and
+    # real root. See https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
+    add_requires coreos-teardown-initramfs-network.service ignition-complete.target
+
     # Invoke distro hook for detecting whether we're booted from a live image,
     # and therefore won't have a root disk.
     if ! command -v is-live-image >/dev/null || ! is-live-image; then

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -39,10 +39,6 @@ add_requires() {
 if $(cmdline_bool 'ignition.firstboot' 0); then
     add_requires ignition-complete.target initrd.target
 
-    # For consistency tear down the network between the initramfs and
-    # real root. See https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
-    add_requires coreos-teardown-initramfs-network.service ignition-complete.target
-
     # Invoke distro hook for detecting whether we're booted from a live image,
     # and therefore won't have a root disk.
     if ! command -v is-live-image >/dev/null || ! is-live-image; then

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -65,8 +65,7 @@ install() {
     # real root. See https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
     inst_script "$moddir/coreos-teardown-initramfs-network.sh" \
         "/usr/sbin/coreos-teardown-initramfs-network"
-    inst_simple "$moddir/coreos-teardown-initramfs-network.service" \
-        "$systemdutildir/system/coreos-teardown-initramfs-network.service"
+    install_ignition_unit coreos-teardown-initramfs-network.service
 
     install_ignition_unit ignition-setup-base.service
     install_ignition_unit ignition-setup-user.service

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -61,6 +61,13 @@ install() {
             "$systemdsystemunitdir/ignition-$x.target"
     done
 
+    # For consistency tear down the network between the initramfs and
+    # real root. See https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
+    inst_script "$moddir/coreos-teardown-initramfs-network.sh" \
+        "/usr/sbin/coreos-teardown-initramfs-network"
+    inst_simple "$moddir/coreos-teardown-initramfs-network.service" \
+        "$systemdutildir/system/coreos-teardown-initramfs-network.service"
+
     install_ignition_unit ignition-setup-base.service
     install_ignition_unit ignition-setup-user.service
     install_ignition_unit ignition-fetch.service


### PR DESCRIPTION
This is a forward port of coreos-teardown-initramfs-network.service
from the spec2x branch [1] (used for RHEL CoreOS). When moving to NM
in the initrd [2] we decided that we also needed a mechanism to take down
the networking between the initramfs and the real root. While we would
like to use NetworkManager's logic to do this operation in the future
it's currently not easily achieved because NetworkManager is not running
persistently in the initramfs [3].

Additionally, we have decided to propagate initramfs networking configuration
in some scenarios [4]. The policy here is:

- If a networking configuration was provided before this point
  (most likely via Ignition) and exists in the real root then
  we do nothing and don't propagate any initramfs networking.
- If a user did not provide any networking configuration
  then we'll propagate the initramfs networking configuration
  into the real root.


[1] https://github.com/coreos/ignition-dracut/pull/78
[2] https://github.com/coreos/fedora-coreos-tracker/issues/394
[3] https://bugzilla.redhat.com/show_bug.cgi?id=1814038
[4] https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721173
