### PR TITLE
Dracut dependency cleanup

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -17,21 +17,15 @@ install_ignition_unit() {
 
 install() {
     inst_multiple \
-        chroot \
         groupadd \
-        id \
         lsblk \
         mkfs.ext4 \
         mkfs.vfat \
         mkfs.xfs \
         mkswap \
-        mountpoint \
         sgdisk \
-        systemd-detect-virt \
         useradd \
-        usermod \
-        realpath \
-        touch
+        usermod
 
     # This one is optional; https://src.fedoraproject.org/rpms/ignition/pull-request/9
     inst_multiple -o mkfs.btrfs

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -17,8 +17,14 @@ install_ignition_unit() {
 
 install() {
     inst_multiple \
+        lsblk
+
+    # Not all features of the configuration may be available on all systems
+    # (e.g. on embedded systems), so only add applications which are actually
+    # present
+    inst_multiple -o \
         groupadd \
-        lsblk \
+        mkfs.btrfs \
         mkfs.ext4 \
         mkfs.vfat \
         mkfs.xfs \
@@ -26,9 +32,6 @@ install() {
         sgdisk \
         useradd \
         usermod
-
-    # This one is optional; https://src.fedoraproject.org/rpms/ignition/pull-request/9
-    inst_multiple -o mkfs.btrfs
 
     # Required by s390x's z/VM installation.
     # Supporting https://github.com/coreos/ignition/pull/865


### PR DESCRIPTION
When trying to reduce the size of the initrd we noticed that several dependencies in the dracut setup script are obsolete (first commit) or inconsistently flagged as optional vs. mandatory (second patch).

This patch set is cleaning this up and uses a consistent and more flexible pattern for optional / mandatory requirements.