### PR TITLE
Add `basename` dependency to dracut module

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -17,6 +17,7 @@ install_ignition_unit() {
 
 install() {
     inst_multiple \
+        basename \
         lsblk
 
     # Not all features of the configuration may be available on all systems


### PR DESCRIPTION
Required by the recent addition of coreos-teardown-initramfs-network.service.