### PR TITLE
coreos-teardown-initramfs-network: order ExecStop after other ignition units

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs-network.service
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.service
@@ -5,6 +5,17 @@
 [Unit]
 Description=Tear down initramfs networking
 DefaultDependencies=false
+
+# We want to run the teardown after all other Ignition stages
+# have run because some platforms (like Packet) do remote status
+# reporting for each Ignition stage. Since we are tearing down
+# the networking using an ExecStop we need to make sure we run
+# the ExecStop *after* any other ignition*.service unit's ExecStop.
+# The only other one right now is ignition-mount that has an ExecStop
+# for doing an unmount. Since the ordering for ExecStop is the
+# opposite of ExecStart we need to use `Before=ignition-mount.service`.
+# https://github.com/coreos/fedora-coreos-tracker/issues/440
+Before=ignition-mount.service
 Before=ignition-complete.target
 
 # Make sure ExecStop= runs before we switch root

--- a/dracut/30ignition/coreos-teardown-initramfs-network.service
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.service
@@ -5,7 +5,6 @@
 [Unit]
 Description=Tear down initramfs networking
 DefaultDependencies=false
-After=ignition-files.service
 Before=ignition-complete.target
 
 # Make sure ExecStop= runs before we switch root


### PR DESCRIPTION
We want to run the teardown after all other Ignition stages
have run because some platforms (like Packet) do remote status
reporting for each Ignition stage. Since we are tearing down
the networking using an ExecStop we need to make sure we run
the ExecStop *after* any other ignition*.service unit's ExecStop.
The only other one right now is ignition-mount that has an ExecStop
for doing an unmount. Since the ordering for ExecStop is the
opposite of ExecStart we need to use `Before=ignition-mount.service`.

Partial fix for https://github.com/coreos/fedora-coreos-tracker/issues/440

This would most likely not be necessary if Ignition cached an
empty result: https://github.com/coreos/ignition/issues/950
