### PR TITLE
Add new ignition-fetch-offline.service

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs.sh
@@ -17,7 +17,7 @@ load_dracut_libs() {
 dracut_func() {
     # dracut is not friendly to set -eu
     set +euo pipefail
-    "$@"; rc=$?
+    "$@"; local rc=$?
     set -euo pipefail
     return $rc
 }

--- a/dracut/30ignition/ignition-check-neednet.sh
+++ b/dracut/30ignition/ignition-check-neednet.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+set +euo pipefail
+. /usr/lib/dracut-lib.sh
+set -euo pipefail
+
+dracut_func() {
+    # dracut is not friendly to set -eu
+    set +euo pipefail
+    "$@"; local rc=$?
+    set -euo pipefail
+    return $rc
+}
+
+# If we need networking and it hasn't been requested yet, request it.
+if [ -f /run/ignition/neednet ] && ! dracut_func getargbool 0 'rd.neednet'; then
+    echo "rd.neednet=1" > /etc/cmdline.d/40-ignition-neednet.conf
+
+    # Hack: we need to rerun the NM cmdline hook because we run after
+    # dracut-cmdline.service because we need udev. We should be able to move
+    # away from this once we run NM as a systemd unit. See also:
+    # https://github.com/coreos/fedora-coreos-config/pull/346#discussion_r409843428
+    set +euo pipefail
+    . /usr/lib/dracut/hooks/cmdline/99-nm-config.sh
+    set -euo pipefail
+fi

--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -5,7 +5,7 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 
-# Stage order: setup -> fetch -> disks -> mount -> files.
+# Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
 After=ignition-fetch.service
 Before=ignition-mount.service
 

--- a/dracut/30ignition/ignition-fetch-offline.service
+++ b/dracut/30ignition/ignition-fetch-offline.service
@@ -1,26 +1,28 @@
 [Unit]
-Description=Ignition (fetch)
+Description=Ignition (fetch-offline)
 Documentation=https://github.com/coreos/ignition
 ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 After=basic.target
-ConditionPathExists=/run/ignition/neednet
 
 # Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
 # We run after the setup stage has run because it may copy in new/different
 # ignition configs for us to consume.
-After=ignition-fetch-offline.service
-Before=ignition-disks.service
+After=ignition-setup-base.service
+After=ignition-setup-user.service
+Before=ignition-fetch.service
 
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 
-# If we run, we definitely need network, so make sure we run after.
-After=network.target
+# See hack in ignition-check-neednet, as well as coreos-copy-firstboot-network.service.
+After=dracut-cmdline.service
+Before=dracut-initqueue.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/run/ignition.env
-ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch
+ExecStart=/usr/bin/ignition --root=/sysroot --platform=${PLATFORM_ID} --stage=fetch-offline
+ExecStart=/usr/sbin/ignition-check-neednet

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -8,7 +8,7 @@ Before=ignition-complete.target
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 
-# Stage order: setup -> fetch -> disks -> mount -> files.
+# Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
 After=ignition-mount.service
 
 # Run before initrd-parse-etc so that we can drop files it then picks up.

--- a/dracut/30ignition/ignition-mount.service
+++ b/dracut/30ignition/ignition-mount.service
@@ -5,6 +5,13 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 
+# Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
+# We need to make sure the partitions and filesystems are set up before
+# mounting. This is also guaranteed through After=initrd-root-fs.target but
+# just to be explicit.
+After=ignition-disks.service
+Before=ignition-files.service
+
 # Make sure ExecStop= runs before we switch root
 Before=initrd-switch-root.target
 
@@ -17,13 +24,6 @@ After=initrd-root-fs.target
 
 # Make sure root filesystem is remounted read-write if needed
 After=ignition-remount-sysroot.service
-
-# Stage order: setup -> fetch -> disks -> mount -> files.
-# We need to make sure the partitions and filesystems are set up before
-# mounting. This is also guaranteed through After=initrd-root-fs.target but
-# just to be explicit.
-After=ignition-disks.service
-Before=ignition-files.service
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-setup-base.service
+++ b/dracut/30ignition/ignition-setup-base.service
@@ -8,8 +8,8 @@ Before=ignition-complete.target
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 
-# Stage order: setup -> fetch -> disks -> mount -> files.
-Before=ignition-fetch.service
+# Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
+Before=ignition-fetch-offline.service
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-setup-user.service
+++ b/dracut/30ignition/ignition-setup-user.service
@@ -8,8 +8,8 @@ Before=ignition-complete.target
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 
-# Stage order: setup -> fetch -> disks -> mount -> files.
-Before=ignition-fetch.service
+# Stage order: setup -> fetch-offline [-> fetch] -> disks -> mount -> files.
+Before=ignition-fetch-offline.service
 
 # We want to make sure we're not racing with multipath taking ownership of the
 # boot device.

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -49,6 +49,8 @@ install() {
         "/usr/sbin/ignition-setup-base"
     inst_script "$moddir/ignition-setup-user.sh" \
         "/usr/sbin/ignition-setup-user"
+    inst_script "$moddir/ignition-check-neednet.sh" \
+        "/usr/sbin/ignition-check-neednet"
 
     # Distro packaging is expected to install the ignition binary into the
     # module directory.
@@ -72,6 +74,7 @@ install() {
     install_ignition_unit ignition-setup-base.service
     install_ignition_unit ignition-setup-user.service
     install_ignition_unit ignition-fetch.service
+    install_ignition_unit ignition-fetch-offline.service
     install_ignition_unit ignition-disks.service
     install_ignition_unit ignition-mount.service
     install_ignition_unit ignition-files.service


### PR DESCRIPTION
Make use of the new `fetch-offline` stage:

coreos/ignition#979

We run this between the `setup` and `fetch` stages (the latter possibly
being skipped if networking is not required).

We hit the same issue here that `coreos-copy-firstboot-network.service`
hit, which is that we can't run before the `cmdline` hook because that
runs *before* udev, but we want the `by-*` symlinks for
`ignition-setup-user.service`.

The hack we do here is to rerun the NM cmdline hook in case ignition
dropped a snippet in `/etc/cmdline.d`. As mentioned in
coreos/fedora-coreos-config#346, we'll be able
to do this more cleanly once we run NM as a systemd service directly.

