### PR TITLE
[spec2x] systemd: don't try to mark live boots complete

### DIFF
--- a/systemd/ignition-firstboot-complete.service
+++ b/systemd/ignition-firstboot-complete.service
@@ -2,6 +2,7 @@
 Description=Mark boot complete
 Documentation=https://github.com/coreos/ignition
 ConditionKernelCommandLine=ignition.firstboot
+ConditionPathExists=!/run/ostree-live
 RequiresMountsFor=/boot
 
 [Service]


### PR DESCRIPTION
In live boots there's no /boot partition with a flag file to remove.

(cherry picked from commit eb48c1892b5854373d8d51e84726a0876a5b6167)