### PR TITLE
ignition-setup-user: for DM boot-device get path from lsblk, instead of using /dev/disk/by-label/boot

### DIFF
--- a/dracut/30ignition/ignition-setup-user.sh
+++ b/dracut/30ignition/ignition-setup-user.sh
@@ -23,10 +23,14 @@ else
     # under $bootmnt/ignition/config.ign. Note that we mount /boot
     # but we don't unmount boot because we are run in a systemd unit
     # with MountFlags=slave so it is unmounted for us.
+    bootpath=$(lsblk --list --paths --output LABEL,NAME | grep mapper | grep boot | awk '{print $2}') || echo -n ''
+    if [ -z $bootpath ]; then
+        bootpath="/dev/disk/by-label/boot"
+    fi
     bootmnt=/mnt/boot_partition
     mkdir -p $bootmnt
     # mount as read-only since we don't strictly need write access and we may be
     # running alongside other code that also has it mounted ro
-    mount -o ro /dev/disk/by-label/boot $bootmnt
+    mount -o ro $bootpath $bootmnt
     copy_file_if_exists "${bootmnt}/ignition/config.ign" "${destination}/user.ign"
 fi


### PR DESCRIPTION
Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>