### PR TITLE
Add ignition-virtio-dump-journal.service

### DIFF
--- a/dracut/99emergency-timeout/ignition-virtio-dump-journal.service
+++ b/dracut/99emergency-timeout/ignition-virtio-dump-journal.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ignition (virtio dump)
+Documentation=https://github.com/coreos/ignition
+ConditionPathExists=/etc/initrd-release
+DefaultDependencies=false
+ConditionVirtualization=|kvm
+ConditionVirtualization=|qemu
+After=basic.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=/run/ignition.env
+ExecStart=/usr/bin/ignition-virtio-dump-journal
+

--- a/dracut/99emergency-timeout/ignition-virtio-dump-journal.sh
+++ b/dracut/99emergency-timeout/ignition-virtio-dump-journal.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+port=/dev/virtio-ports/com.coreos.ignition.journal
+if [ -e "${port}" ]; then
+    journalctl -o json > "${port}"
+    # And this signals end of stream
+    echo '{}' > "${port}"
+else
+    echo "Didn't find virtio port ${port}"
+fi

--- a/dracut/99emergency-timeout/module-setup.sh
+++ b/dracut/99emergency-timeout/module-setup.sh
@@ -2,10 +2,22 @@
 # -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
 # ex: ts=8 sw=4 sts=4 et filetype=sh
 
+install_unit_wants() {
+    local unit="$1"; shift
+    local target="$1"; shift
+    local instantiated="${1:-$unit}"; shift
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    mkdir -p "$initdir/$systemdsystemunitdir/$target.wants"
+    ln_r "../$unit" "$systemdsystemunitdir/$target.wants/$instantiated"
+}
+
 install() {
     inst_multiple \
         cut \
         date
 
     inst_hook emergency 99 "${moddir}/timeout.sh"
+
+    inst_script "$moddir/ignition-virtio-dump-journal.sh" "/usr/bin/ignition-virtio-dump-journal"
+    install_unit_wants ignition-virtio-dump-journal.service emergency.target
 }


### PR DESCRIPTION
Debugging failures in the initrd is annoying; this code
looks for a virtio-serial port named `com.coreos.ignition.journal`,
and runs as part of `emergency.target`.

I plan to change mantle to set up this port by default, so if
something fails in the initramfs we'll at least reliably get
the journal in a sane parsable format.

This is a special targeted subset of
https://github.com/coreos/ignition/issues/585

(cherry picked from commit 84c89f4a5fa5b32c39df01e6ec5fd081050daa62)