### PR TITLE
[spec2x] 30ignition: fix ordering of fetch, disks, and files 

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -17,9 +17,7 @@ After=basic.target
 Before=initrd-root-fs.target
 Before=sysroot.mount
 
-# Run after ignition-setup has run because ignition-setup
-# may copy in new/different ignition configs for us to consume.
-After=ignition-setup.service
+After=ignition-fetch.service
 
 # Network may be used to fetch userdata content.
 After=network.target

--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -6,9 +6,8 @@ After=basic.target
 
 # Run after ignition-setup has run because ignition-setup
 # may copy in new/different ignition configs for us to consume.
-After=ignition-setup.service
-Before=ignition-disks.service
-Before=ignition-files.service
+After=ignition-setup-base.service
+After=ignition-setup-user.service
 
 # Network may be used to fetch userdata content.
 After=network.target

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -11,10 +11,6 @@ OnFailureJobMode=isolate
 Requires=initrd-root-fs.target
 After=initrd-root-fs.target
 
-# Run after ignition-setup has run because ignition-setup
-# may copy in new/different ignition configs for us to consume.
-After=ignition-setup.service
-
 # Make sure root filesystem is mounted read-write
 Requires=ignition-remount-sysroot.service
 After=ignition-remount-sysroot.service

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -34,9 +34,6 @@ install() {
     # This one is optional; https://src.fedoraproject.org/rpms/ignition/pull-request/9
     inst_multiple -o mkfs.btrfs
 
-    inst_script "$moddir/ignition-setup.sh" \
-        "/usr/sbin/ignition-setup"
-
     inst_script "$moddir/coreos-teardown-initramfs-network.sh" \
 	"/usr/sbin/coreos-teardown-initramfs-network"
 


### PR DESCRIPTION
We need to order the `disks` stage after the `fetch` stage, not `setup`.
This is part of the backport of the fetch stage.

We also need to fix the order of the `fetch` stage wrt to the `setup`
service as part of the ignition-setup-{base,user} split backport.