### PR TITLE
setup-user: Accept an existing /boot mount

### DIFF
--- a/dracut/30ignition/ignition-setup-user.sh
+++ b/dracut/30ignition/ignition-setup-user.sh
@@ -23,8 +23,15 @@ else
     # under $bootmnt/ignition/config.ign. Note that we mount /boot
     # but we don't unmount boot because we are run in a systemd unit
     # with MountFlags=slave so it is unmounted for us.
-    bootmnt=/mnt/boot_partition
-    mkdir -p $bootmnt
-    mount /dev/disk/by-label/boot $bootmnt
+    # Note that /boot may already be mounted; if so, use it.
+    if findmnt /boot 2>/dev/null; then
+        bootmnt=/boot
+    else
+        bootmnt=/mnt/boot_partition
+        mkdir -p $bootmnt
+        # mount as read-only since we don't strictly need write access and we may be
+        # running alongside other code that also has it mounted ro
+        mount -o ro /dev/disk/by-label/boot $bootmnt
+    fi
     copy_file_if_exists "${bootmnt}/ignition/config.ign" "${destination}/user.ign"
 fi


### PR DESCRIPTION
For RHCOS, dracut mounts `/boot` in the FIPS case, and things
blow up if we try to mount it twice.

Also bigger picture at this point we have a crap ton of services
all trying to mount `/boot`; we might as well just add a `boot.mount`
unit to our initramfs.