### PR TITLE
setup: Do nothing if PLATFORM_ID is unset

### DIFF
--- a/dracut/30ignition/ignition-setup-base.sh
+++ b/dracut/30ignition/ignition-setup-base.sh
@@ -16,4 +16,6 @@ mkdir -p $destination
 
 # We will support grabbing a platform specific base.ign config
 # from the initrd at /usr/lib/ignition/platform/${PLATFORM_ID}/base.ign
-copy_file_if_exists "/usr/lib/ignition/platform/${PLATFORM_ID}/base.ign" "${destination}/base.ign"
+if [ -n "${PLATFORM_ID:-}" ]; then
+    copy_file_if_exists "/usr/lib/ignition/platform/${PLATFORM_ID}/base.ign" "${destination}/base.ign"
+fi


### PR DESCRIPTION
This currently occurs in the "synthetic" RHCOS upgrade test.