### PR TITLE
coreos-teardown-initramfs-network: propagate hostname, support coreos.no_persist_ip

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -65,8 +65,12 @@ down_interfaces() {
         for f in /sys/class/net/*; do
             interface=$(basename "$f")
             # The `bonding_masters` entry is not a true interface and thus
-            # cannot be taken down.
-            if [ "$interface" == "bonding_masters" ]; then continue; fi
+            # cannot be taken down. Also skip local loopback
+            case "$interface" in
+                "lo" | "bonding_masters")
+                    continue
+                    ;;
+            esac
             down_interface $interface
         done
     fi

--- a/dracut/30ignition/coreos-teardown-initramfs-network.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.sh
@@ -26,7 +26,10 @@ selinux_relabel() {
 #
 # See https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721173
 propagate_initramfs_networking() {
-    if [ -n "$(ls -A /sysroot/etc/NetworkManager/system-connections/)" ]; then
+    # Check the two locations where a user could have provided network configuration
+    # On FCOS we only support keyfiles, but on RHCOS we support keyfiles and ifcfg
+    if [ -n "$(ls -A /sysroot/etc/NetworkManager/system-connections/)" -o \
+         -n "$(ls -A /sysroot/etc/sysconfig/network-scripts/)" ]; then
         echo "info: networking config is defined in the real root"
         echo "info: will not attempt to propagate initramfs networking"
     else


### PR DESCRIPTION
There are several improvements to the coreos-teardown-initramfs-network script in this patchset. The most significant are: support for propagating the hostname to the real root if it was provided via static networking ip= kargs and also adding support for the coreos.no_persist_ip karg. Please see each commit for the full details on each change.

- coreos-teardown-initramfs-network: also propagate hostname
- coreos-teardown-initramfs-network: support coreos.no_persist_ip karg
- coreos-teardown-initramfs-network: do SELinux relabel on copied files
