### PR TITLE
30ignition: drop hard requirement on qemu_fw_cfg

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -83,26 +83,3 @@ install() {
     # needed for openstack config drive support
     inst_rules 60-cdrom_id.rules
 }
-
-has_fw_cfg_module() {
-    # this is like check_kernel_config() but it specifically checks for `m` and
-    # also checks the OSTree-specific kernel location
-    for path in /boot/config-$kernel \
-                /usr/lib/modules/$kernel/config \
-                /usr/lib/ostree-boot/config-$kernel; do
-        if test -f $path; then
-            rc=0
-            grep -q CONFIG_FW_CFG_SYSFS=m $path || rc=$?
-            return $rc
-        fi
-    done
-    return 1
-}
-
-installkernel() {
-    # We definitely need this one in the initrd to support Ignition cfgs on qemu
-    # if available
-    if has_fw_cfg_module; then
-        instmods -c qemu_fw_cfg
-    fi
-}


### PR DESCRIPTION
The original intent here was that on arches where `fw_cfg` is available,
then we definitely want to make sure that either it's built into the
kernel or if a module, added to the initrd. However, this check has been
watered down now to to the point where it's not that useful.

In https://github.com/coreos/ignition-dracut/issues/176, there's a
reasonable request to support not having the `qemu_fw_cfg` module
installed at all even if the architecture would support it.

IMO, I think we should just drop this whole logic entirely. The `qemu`
module (which we depend on) already does an `instmods qemu_fw_cfg`
(without `-c`), and qemu testing is the backbone of our CI testing. So
realistically, we would notice very fast if `fw_cfg` support in the
initrd went missing.

Closes: #176