### PR TITLE
coreos-teardown-initramfs-network: don't run when emergency.target

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs-network.service
+++ b/dracut/30ignition/coreos-teardown-initramfs-network.service
@@ -26,6 +26,13 @@ Before=initrd-switch-root.target
 OnFailure=emergency.target
 OnFailureJobMode=isolate
 
+# If we are already heading towards emergency.target
+# then don't try to stop this unit because it will fail
+# when trying to access files in /sysroot/etc/. The failure
+# is mostly harmless but having the extra error messages
+# leads us away from the original problem.
+IgnoreOnIsolate=true
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
If another unit failed (like ignition-fetch.service) then don't run
the ExecStop when isolating to emergency.target. We can do this by
setting IgnoreOnIsolate=true.

Otherwise you end up with errors like the following in the logs,
which can lead someone investigating a problem in the wrong direction.

```
Stopping Tear down initramfs networking...
info: taking down network device: eth0
RTNETLINK answers: Operation not supported
info: flushing all routing
info: no initramfs hostname information to propagate
ls: cannot access '/sysroot/etc/NetworkManager/system-connections/': No such file or directory
ls: cannot access '/sysroot/etc/sysconfig/network-scripts/': No such file or directory
info: no networking config is defined in the real root
info: propagating initramfs networking config to the real root
cp: cannot create regular file '/sysroot/etc/NetworkManager/system-connections/': No such file or directory
```