### PR TITLE
ignition-udev-service: add support for root on multipath

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs.service
+++ b/dracut/30ignition/coreos-teardown-initramfs.service
@@ -3,7 +3,7 @@
 # https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
 
 [Unit]
-Description=Tear down initramfs networking
+Description=CoreOS Tear down initramfs
 DefaultDependencies=false
 
 # We want to run the teardown after all other Ignition stages
@@ -36,4 +36,4 @@ IgnoreOnIsolate=true
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStop=/usr/sbin/coreos-teardown-initramfs-network
+ExecStop=/usr/sbin/coreos-teardown-initramfs

--- a/dracut/30ignition/ignition-diskful-complex-mpath.service
+++ b/dracut/30ignition/ignition-diskful-complex-mpath.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Ignition Diskful Complex Devices Multipath
+Documentation=https://github.com/coreos/ignition
+
+Before=ignition-diskful.target
+Before=ignition-diskful-subsequent.target
+Before=ignition-subsequent.target
+
+After=ignition-setup-user.service
+After=ignition-setup-base.service
+
+ConditionPathExists=/etc/multipath.conf
+ConditionKernelCommandLine=!nompath
+ConditionKernelCommandLine=!rd.multipath=0
+ConditionKernelCommandLine=!rd_NO_MULTIPATH
+ConditionKernelCommandLine=!multipath=off
+
+# Wait for multipathd
+Wants=multipathd.service
+After=multipathd.service
+
+# We need sysinit.target to be ready in order to use udev
+# triggers. Otherwise triggering will have no effect.
+Requires=sysinit.target systemd-udevd.service
+After=sysinit.target systemd-udevd.service systemd-udev-settle.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Have to shell out since we need shell expansion of the *
+# We wait to settle the devices to ensure that the symlinks are created
+# before proceeding.
+ExecStart=-/bin/sh -c '/usr/bin/udevadm trigger --settle --verbose /dev/dm*'

--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -68,4 +68,9 @@ else
     fi
 fi
 
+if $(cmdline_bool 'rd.multipath' 0); then
+    add_requires ignition-diskful-complex-mpath.service ignition-diskful.target
+    add_requires ignition-diskful-complex-mpath.service ignition-diskful-subsequent.target
+fi
+
 echo "PLATFORM_ID=$(cmdline_arg ignition.platform.id)" > /run/ignition.env

--- a/dracut/30ignition/ignition-setup-base.service
+++ b/dracut/30ignition/ignition-setup-base.service
@@ -5,9 +5,9 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 
-Before=local-fs-pre.target
-Before=ignition-disks.service
-Before=ignition-files.service
+Before=ignition-diskful.target
+Before=dracut-initqueue.service
+After=dracut-cmdline.service
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-setup-user.service
+++ b/dracut/30ignition/ignition-setup-user.service
@@ -5,9 +5,9 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 
-Before=local-fs-pre.target
-Before=ignition-disks.service
-Before=ignition-files.service
+Before=ignition-diskful.target
+Before=dracut-initqueue.service
+After=dracut-cmdline.service
 
 # On diskful boots, ignition-generator adds Requires/After on
 # dev-disk-by\x2dlabel-boot.device.

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -62,11 +62,14 @@ install() {
             "$systemdsystemunitdir/ignition-$x.target"
     done
 
-    # For consistency tear down the network between the initramfs and
+    inst_script "$moddir/ignition-diskful-complex-mpath.service" \
+         "$systemdsystemunitdir/ignition-diskful-complex-mpath.service"
+
+    # For consistency tear down the network and persist multipath between the initramfs and
     # real root. See https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
-    inst_script "$moddir/coreos-teardown-initramfs-network.sh" \
-        "/usr/sbin/coreos-teardown-initramfs-network"
-    install_ignition_unit coreos-teardown-initramfs-network.service
+    inst_script "$moddir/coreos-teardown-initramfs.sh" \
+        "/usr/sbin/coreos-teardown-initramfs"
+    install_ignition_unit coreos-teardown-initramfs.service
 
     install_ignition_unit ignition-setup-base.service
     install_ignition_unit ignition-setup-user.service


### PR DESCRIPTION
This provides support for multipath without having to re-order
everything or provide a new target. We need to trigger udev to update
the device symlinks in `/dev/disk/by-{id,label,uuid}` for multipath
devices after multipathd has run.

This also reorders some services to run in "RO" before the multipathd target
is setup and then moves the "RW" after device-mapper targets have been
found.

Signed-off-by: Ben Howard <ben.howard@redhat.com>