### PR TITLE
Sync ignition-remount-sysroot.service handling with master

### DIFF
--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -12,7 +12,6 @@ Requires=initrd-root-fs.target
 After=initrd-root-fs.target
 
 # Make sure root filesystem is mounted read-write
-Requires=ignition-remount-sysroot.service
 After=ignition-remount-sysroot.service
 
 # Run before initrd-parse-etc so that we can drop files it then picks up.

--- a/dracut/30ignition/ignition-remount-sysroot.service
+++ b/dracut/30ignition/ignition-remount-sysroot.service
@@ -4,7 +4,7 @@ Description=Remount /sysroot read-write for Ignition
 # commandline and thus mount the root filesystem ro by default. In
 # this case, remount /sysroot to rw (issue #37)
 DefaultDependencies=no
-Before=initrd.target
+Before=ignition-diskful.target
 After=sysroot.mount
 ConditionPathIsReadWrite=!/sysroot
 


### PR DESCRIPTION
For RHCOS https://github.com/coreos/coreos-assembler/pull/1420
broke things because `ignition-files.service` was unconditionally
pulling in `ignition-remount-sysroot.service` when it should
only be activated by `ignition-diskful.target`.

Sync things up with master here.