### PR TITLE
Cleanups and small patch for multipathd

### DIFF
--- a/dracut/30ignition/ignition-disks.service
+++ b/dracut/30ignition/ignition-disks.service
@@ -4,7 +4,10 @@ Documentation=https://github.com/coreos/ignition
 ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
+
+# Stage order: setup -> fetch -> disks -> mount -> files.
 After=ignition-fetch.service
+Before=ignition-mount.service
 
 # This stage runs between `basic.target` and `initrd-root-device.target`,
 # see https://www.freedesktop.org/software/systemd/man/bootup.html

--- a/dracut/30ignition/ignition-fetch.service
+++ b/dracut/30ignition/ignition-fetch.service
@@ -6,10 +6,13 @@ DefaultDependencies=false
 Before=ignition-complete.target
 After=basic.target
 
-# Run after ignition-setup has run because ignition-setup
-# may copy in new/different ignition configs for us to consume.
+# Stage order: setup -> fetch -> disks -> mount -> files.
+# We run after the setup stage has run because it may copy in new/different
+# ignition configs for us to consume.
 After=ignition-setup-base.service
 After=ignition-setup-user.service
+Before=ignition-disks.service
+
 
 # Network may be used to fetch userdata content.
 After=network.target

--- a/dracut/30ignition/ignition-files.service
+++ b/dracut/30ignition/ignition-files.service
@@ -5,8 +5,7 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 
-# We need all the filesystems already mounted.
-Requires=ignition-mount.service
+# Stage order: setup -> fetch -> disks -> mount -> files.
 After=ignition-mount.service
 
 # Run before initrd-parse-etc so that we can drop files it then picks up.

--- a/dracut/30ignition/ignition-mount.service
+++ b/dracut/30ignition/ignition-mount.service
@@ -19,9 +19,12 @@ After=initrd-root-fs.target
 # Make sure root filesystem is remounted read-write if needed
 After=ignition-remount-sysroot.service
 
-# This is guaranteed through After=initrd-root-fs.target but just to
-# be explicit.
+# Stage order: setup -> fetch -> disks -> mount -> files.
+# We need to make sure the partitions and filesystems are set up before
+# mounting. This is also guaranteed through After=initrd-root-fs.target but
+# just to be explicit.
 After=ignition-disks.service
+Before=ignition-files.service
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-setup-base.service
+++ b/dracut/30ignition/ignition-setup-base.service
@@ -5,9 +5,8 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 
-Before=local-fs-pre.target
-Before=ignition-disks.service
-Before=ignition-files.service
+# Stage order: setup -> fetch -> disks -> mount -> files.
+Before=ignition-fetch.service
 
 [Service]
 Type=oneshot

--- a/dracut/30ignition/ignition-setup-user.service
+++ b/dracut/30ignition/ignition-setup-user.service
@@ -5,9 +5,8 @@ ConditionPathExists=/etc/initrd-release
 DefaultDependencies=false
 Before=ignition-complete.target
 
-Before=local-fs-pre.target
-Before=ignition-disks.service
-Before=ignition-files.service
+# Stage order: setup -> fetch -> disks -> mount -> files.
+Before=ignition-fetch.service
 
 # On diskful boots, ignition-generator adds Requires/After on
 # dev-disk-by\x2dlabel-boot.device.

--- a/dracut/30ignition/ignition-setup-user.service
+++ b/dracut/30ignition/ignition-setup-user.service
@@ -8,6 +8,10 @@ Before=ignition-complete.target
 # Stage order: setup -> fetch -> disks -> mount -> files.
 Before=ignition-fetch.service
 
+# We want to make sure we're not racing with multipath taking ownership of the
+# boot device.
+Before=multipathd.service
+
 # On diskful boots, ignition-generator adds Requires/After on
 # dev-disk-by\x2dlabel-boot.device.
 


### PR DESCRIPTION
Individual commit messages:

```
30ignition: clean up Ignition stages ordering 

First, put the order of the stages in every unit file. Then, make sure
to include both the appropriate `After=` and `Before=` in accordance
with the unit's place in the chain. There's redundancy there, but it
makes it really obvious and explicit how they go together.
```

```
ignition-setup-user.service: run before multipathd

This is required because the unit needs read-only access to `/boot` in
order to extract any baked in user-provided config and multipathd might
claim ownership.

See: #183
```