### PR TITLE
coreos-teardown-initramfs: propagate the automatic multipath conf

### DIFF
--- a/dracut/30ignition/coreos-teardown-initramfs.service
+++ b/dracut/30ignition/coreos-teardown-initramfs.service
@@ -3,7 +3,7 @@
 # https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
 
 [Unit]
-Description=Tear down initramfs networking
+Description=CoreOS Tear down initramfs
 DefaultDependencies=false
 
 # We want to run the teardown after all other Ignition stages
@@ -36,4 +36,4 @@ IgnoreOnIsolate=true
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStop=/usr/sbin/coreos-teardown-initramfs-network
+ExecStop=/usr/sbin/coreos-teardown-initramfs

--- a/dracut/30ignition/coreos-teardown-initramfs.sh
+++ b/dracut/30ignition/coreos-teardown-initramfs.sh
@@ -100,6 +100,22 @@ propagate_initramfs_hostname() {
     fi
 }
 
+# Persist automatic multipath configuration, if any.
+# When booting with `rd.multipath=default`, the default multipath
+# configuration is written. We need to ensure that the mutlipath configuration
+# is persisted to the final target.
+propagate_initramfs_multipath() {
+    if [ ! -f /sysroot/etc/multipath.conf ] && [ -f /etc/multipath.conf ]; then
+        echo "info: propagating automatic multipath configuration"
+        cp -v /etc/multipath.conf /sysroot/etc/
+        mkdir -p /sysroot/etc/multipath/multipath.conf.d
+        selinux_relabel /etc/multipath.conf
+        selinux_relabel /etc/multipath/multipath.conf.d
+    else
+        echo "info: no initramfs automatic multipath configuration to propagate"
+    fi
+}
+
 down_interface() {
     echo "info: taking down network device: $1"
     # On recommendation from the NM team let's try to delete the device
@@ -162,6 +178,10 @@ main() {
     # clean it up so that no information from outside of the
     # real root is passed on to NetworkManager in the real root
     rm -rf /run/NetworkManager/
+
+    # If automated multipath configuration has been enabled, ensure
+    # that its propagated to the real rootfs.
+    propagate_initramfs_multipath
 }
 
 main

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -62,11 +62,11 @@ install() {
             "$systemdsystemunitdir/ignition-$x.target"
     done
 
-    # For consistency tear down the network between the initramfs and
+    # For consistency tear down the network and persist multipath between the initramfs and
     # real root. See https://github.com/coreos/fedora-coreos-tracker/issues/394#issuecomment-599721763
-    inst_script "$moddir/coreos-teardown-initramfs-network.sh" \
-        "/usr/sbin/coreos-teardown-initramfs-network"
-    install_ignition_unit coreos-teardown-initramfs-network.service
+    inst_script "$moddir/coreos-teardown-initramfs.sh" \
+        "/usr/sbin/coreos-teardown-initramfs"
+    install_ignition_unit coreos-teardown-initramfs.service
 
     install_ignition_unit ignition-setup-base.service
     install_ignition_unit ignition-setup-user.service


### PR DESCRIPTION
Rename coreos-teardown-initramfs-network.* to
coreos-teardown-initramfs.* and add function to propagating automatic
configuration through to boot.

This requires https://github.com/dracutdevs/dracut/commit/b8a92b715677d52dbc2b27a710b9816fd8b9a63b and can be used with https://github.com/coreos/fedora-coreos-config/pull/392

Signed-off-by: Ben Howard <ben.howard@redhat.com>