### PR TITLE
*: add LUKS

### DIFF
--- a/dracut/30ignition/99-xx-ignition-systemd-cryptsetup.rules
+++ b/dracut/30ignition/99-xx-ignition-systemd-cryptsetup.rules
@@ -1,0 +1,8 @@
+SUBSYSTEM!="block", GOTO="systemd_cryptsetup_end"
+
+# This overrides systemd default behavior from 99-systemd.rules, which ignores unformatted crypto devices.
+# https://github.com/systemd/systemd/commit/90e6abaea0cfd25093aae1ad862c5c909ae55829
+# Ignition relies on unformatted crypto devices being discovered to trigger formatting
+SUBSYSTEM=="block", ENV{DM_UUID}=="CRYPT-*", ENV{ID_PART_TABLE_TYPE}=="", ENV{ID_FS_USAGE}=="", ENV{SYSTEMD_READY}:="1"
+
+LABEL="systemd_cryptsetup_end"

--- a/dracut/30ignition/ignition-luks.conf
+++ b/dracut/30ignition/ignition-luks.conf
@@ -1,0 +1,3 @@
+# We don't ship cracklib dicts in the initramfs, so don't check
+# generated clevis keys against them
+dictcheck = 0

--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -35,6 +35,18 @@ install() {
         usermod \
         wipefs
 
+    # Needed for clevis binding; note all binaries related to unlocking are
+    # included by the Clevis dracut modules.
+    inst_multiple -o \
+        clevis-encrypt-sss \
+        clevis-encrypt-tang \
+        clevis-encrypt-tpm2 \
+        clevis-luks-bind \
+        clevis-luks-common-functions \
+        clevis-luks-unlock \
+        pwmake \
+        tpm2_create
+
     # Required by s390x's z/VM installation.
     # Supporting https://github.com/coreos/ignition/pull/865
     inst_multiple -o chccwdev vmur
@@ -56,6 +68,14 @@ install() {
     # module directory.
     inst_simple "$moddir/ignition" \
         "/usr/bin/ignition"
+
+    # Rule to allow udev to discover unformatted encrypted devices
+    inst_simple "$moddir/99-xx-ignition-systemd-cryptsetup.rules" \
+        "/usr/lib/udev/rules.d/99-xx-ignition-systemd-cryptsetup.rules"
+
+    # disable dictcheck
+    inst_simple "$moddir/ignition-luks.conf" \
+        "/etc/security/pwquality.conf.d/ignition-luks.conf"
 
     inst_simple "$moddir/ignition-generator" \
         "$systemdutildir/system-generators/ignition-generator"


### PR DESCRIPTION
Adds LUKS related binaries to dracut, a new unit that copies keyfiles
from the initramfs to the real root, a generator for unlocking clevis
devices, a udev rule to discover unformatted encrypted devices, and two
cracklib files needed by clevis in the initramfs.