### PR TITLE
30ignition/generator: don't turn on diskful targets for legacy installer

### DIFF
--- a/dracut/30ignition/ignition-generator
+++ b/dracut/30ignition/ignition-generator
@@ -45,7 +45,8 @@ if $(cmdline_bool 'ignition.firstboot' 0); then
 
     # Invoke distro hook for detecting whether we're booted from a live image,
     # and therefore won't have a root disk.
-    if ! command -v is-live-image >/dev/null || ! is-live-image; then
+    if ! test -f /etc/coreos-legacy-installer-initramfs && \
+            (! command -v is-live-image >/dev/null || ! is-live-image); then
         add_requires ignition-diskful.target ignition-complete.target
 
         # ignition-setup-user.service should depend on the boot device node
@@ -65,7 +66,8 @@ else
     # like `ignition-ostree-mount-sysroot.service`
     # can cleanly distinguish between the two.
     add_requires ignition-subsequent.target initrd.target
-    if ! command -v is-live-image >/dev/null || ! is-live-image; then
+    if ! test -f /etc/coreos-legacy-installer-initramfs && \
+            (! command -v is-live-image >/dev/null || ! is-live-image); then
         add_requires ignition-diskful-subsequent.target ignition-subsequent.target
     fi
 fi


### PR DESCRIPTION
We're shipping both the new and the legacy installer right now in RHCOS
to ease the transition. We need to make sure that we don't turn on the
diskful targets there.

Since we're also planning to move to spec3, we need this in master too.