### PR TITLE
make: install systemd unit as non-executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ install: all
 	  bn=$$(basename $$x); \
 	  install -D -t $(DESTDIR)/usr/lib/dracut/modules.d/$${bn} $$x/*; \
 	done
-	install -D -t $(DESTDIR)/usr/lib/systemd/system systemd/*
+	install -D -m 644 -t $(DESTDIR)/usr/lib/systemd/system systemd/*


### PR DESCRIPTION
This tweaks permissions when installing units in order to avoid
the following warning at boot time:
```
systemd[1]: Configuration file /usr/lib/systemd/system/ignition-firstboot-complete.service is marked executable.
 Please remove executable permission bits. Proceeding anyway.
```