### PR TITLE
dracut/30ignition: Add packages to delete users/groups

### DIFF
--- a/dracut/30ignition/module-setup.sh
+++ b/dracut/30ignition/module-setup.sh
@@ -25,6 +25,7 @@ install() {
     # present
     inst_multiple -o \
         groupadd \
+        groupdel \
         mkfs.btrfs \
         mkfs.ext4 \
         mkfs.vfat \
@@ -32,6 +33,7 @@ install() {
         mkswap \
         sgdisk \
         useradd \
+        userdel \
         usermod \
         wipefs
 


### PR DESCRIPTION
This PR adds two packages namely `groupdel` and `userdel` to delete the existing users/groups from the base OS.
xref: https://github.com/coreos/ignition/issues/738