### PR TITLE
99emergency-timeout/virtio-dump: wait before dumping

### DIFF
--- a/dracut/99emergency-timeout/ignition-virtio-dump-journal.sh
+++ b/dracut/99emergency-timeout/ignition-virtio-dump-journal.sh
@@ -3,6 +3,13 @@ set -euo pipefail
 
 port=/dev/virtio-ports/com.coreos.ignition.journal
 if [ -e "${port}" ]; then
+    # wait for the journal to wind down
+    for i in {1..15}; do
+        if journalctl -q -u systemd-journald.service --grep 'Journal stopped'; then
+            break
+        fi
+        sleep 2
+    done
     journalctl -o json > "${port}"
     # And this signals end of stream
     echo '{}' > "${port}"


### PR DESCRIPTION
When systemd activates us as a result of switching to
`emergency.target`, journald might still be collecting and writing back
messages from various services. If we run too early, we'll be missing
out on those.

As a hack, wait until the 'Journal stopped' message from journald is
written before dumping the whole journal. Timeout at 30s.

---

Putting this here so we don't lose it. Once the ignition-dracut repo is merged, I'll re-open against f-c-c.